### PR TITLE
Add subscription expired page

### DIFF
--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -191,7 +191,8 @@ def user_subscription(
             config_format="clash-meta",
             as_base64=False,
             reverse=False,
-            revoked=is_revoked or is_expired,
+            revoked=is_revoked,
+            expired=is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -203,7 +204,8 @@ def user_subscription(
             config_format="clash",
             as_base64=False,
             reverse=False,
-            revoked=is_revoked or is_expired,
+            revoked=is_revoked,
+            expired=is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -215,7 +217,8 @@ def user_subscription(
             config_format="sing-box",
             as_base64=False,
             reverse=False,
-            revoked=is_revoked or is_expired,
+            revoked=is_revoked,
+            expired=is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -227,7 +230,8 @@ def user_subscription(
             config_format="outline",
             as_base64=False,
             reverse=False,
-            revoked=is_revoked or is_expired,
+            revoked=is_revoked,
+            expired=is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -241,7 +245,8 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=False,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -252,7 +257,8 @@ def user_subscription(
                 config_format="v2ray",
                 as_base64=True,
                 reverse=False,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -266,7 +272,8 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=False,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -277,7 +284,8 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=True,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -288,7 +296,8 @@ def user_subscription(
                 config_format="v2ray",
                 as_base64=True,
                 reverse=False,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -301,7 +310,8 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=False,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -312,7 +322,8 @@ def user_subscription(
                 config_format="v2ray",
                 as_base64=True,
                 reverse=False,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -326,7 +337,8 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=False,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -337,7 +349,8 @@ def user_subscription(
                 config_format="v2ray",
                 as_base64=True,
                 reverse=False,
-                revoked=is_revoked or is_expired,
+                revoked=is_revoked,
+            expired=is_expired,
                 device_limited=device_limited
             )
             return Response(content=conf, media_type="text/plain", headers=response_headers)
@@ -350,7 +363,8 @@ def user_subscription(
             config_format="v2ray",
             as_base64=True,
             reverse=False,
-            revoked=is_revoked or is_expired,
+            revoked=is_revoked,
+            expired=is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -439,7 +453,8 @@ def user_subscription_with_client_type(
                                  config_format=config["config_format"],
                                  as_base64=config["as_base64"],
                                  reverse=config["reverse"],
-                                 revoked=is_revoked or is_expired,
+                                 revoked=is_revoked,
+                                 expired=is_expired,
                                  device_limited=device_limited,
                                  unsupported_client=unsupported_client)
 

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime, timezone
 import math
+from app.db.models import User
 from distutils.version import LooseVersion
 from urllib.parse import quote
 
@@ -63,7 +64,7 @@ def resolve_subscription_context(token: str, db: Session):
     sub = get_subscription_payload(token)
     if not sub:
         return None, False, None
-    dbuser = crud.get_user(db, sub['username'])
+    dbuser: User | None = crud.get_user(db, sub['username'])
     if not dbuser:
         return None, False, None
     # If token created before user record (e.g., renamed/recreated), treat as invalid
@@ -111,10 +112,11 @@ def user_subscription(
     if not dbuser:
         return Response(status_code=404)
     crud.ensure_subscription_token(db, dbuser)
+    is_expired = bool(dbuser.expire and dbuser.expire > 0 and dbuser.expire < int(datetime.now(timezone.utc).timestamp()))
     user: UserResponse = UserResponse.model_validate(dbuser)
 
     html_device_limited = False
-    if not is_revoked and dbuser.device_limit:
+    if not is_revoked and not is_expired and dbuser.device_limit:
         html_device_limited = crud.count_user_devices(db, dbuser) >= dbuser.device_limit
 
     accept_header = request.headers.get("Accept", "")
@@ -123,6 +125,13 @@ def user_subscription(
             return HTMLResponse(
                 render_template(
                     "sub/revoked.html",
+                    {"bot_url": BOT_URL}
+                )
+            )
+        if is_expired:
+            return HTMLResponse(
+                render_template(
+                    "sub/expired.html",
                     {"bot_url": BOT_URL}
                 )
             )
@@ -143,19 +152,21 @@ def user_subscription(
     device_limited = False
     unsupported_client = False
     registered = False
-    if not is_revoked:
+    if not is_revoked and not is_expired:
         registered, unsupported_client = crud.register_user_device(
             db, dbuser, x_hwid, x_device_os, x_ver_os, x_device_model, user_agent
         )
         device_limited = (not registered and not unsupported_client) or crud.is_device_limit_exceeded(db, dbuser)
-    if is_revoked or device_limited or unsupported_client:
+    if is_revoked or is_expired or device_limited or unsupported_client:
         user = get_empty_subscription_user(user)
 
-    if not is_revoked:
+    if not is_revoked and not is_expired:
         crud.update_user_sub(db, dbuser, user_agent)
     announce_text = get_user_note(user) or ""
     if is_revoked:
         announce_text = f"Подписка отозвана. Запросите новую ссылку в боте. {BOT_URL}"
+    elif is_expired:
+        announce_text = f"Подписка истекла. Продлите подписку в боте. {BOT_URL}"
     elif device_limited:
         announce_text = f"Достигнут лимит устройств. Удалите старое устройство или увеличьте лимит в боте. {BOT_URL}"
     elif unsupported_client:
@@ -180,7 +191,7 @@ def user_subscription(
             config_format="clash-meta",
             as_base64=False,
             reverse=False,
-            revoked=is_revoked,
+            revoked=is_revoked or is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -192,7 +203,7 @@ def user_subscription(
             config_format="clash",
             as_base64=False,
             reverse=False,
-            revoked=is_revoked,
+            revoked=is_revoked or is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -204,7 +215,7 @@ def user_subscription(
             config_format="sing-box",
             as_base64=False,
             reverse=False,
-            revoked=is_revoked,
+            revoked=is_revoked or is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -216,7 +227,7 @@ def user_subscription(
             config_format="outline",
             as_base64=False,
             reverse=False,
-            revoked=is_revoked,
+            revoked=is_revoked or is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -230,7 +241,7 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=False,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -241,7 +252,7 @@ def user_subscription(
                 config_format="v2ray",
                 as_base64=True,
                 reverse=False,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -255,7 +266,7 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=False,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -266,7 +277,7 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=True,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -277,7 +288,7 @@ def user_subscription(
                 config_format="v2ray",
                 as_base64=True,
                 reverse=False,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -290,7 +301,7 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=False,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -301,7 +312,7 @@ def user_subscription(
                 config_format="v2ray",
                 as_base64=True,
                 reverse=False,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -315,7 +326,7 @@ def user_subscription(
                 config_format="v2ray-json",
                 as_base64=False,
                 reverse=False,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited,
                 unsupported_client=unsupported_client
             )
@@ -326,7 +337,7 @@ def user_subscription(
                 config_format="v2ray",
                 as_base64=True,
                 reverse=False,
-                revoked=is_revoked,
+                revoked=is_revoked or is_expired,
                 device_limited=device_limited
             )
             return Response(content=conf, media_type="text/plain", headers=response_headers)
@@ -339,7 +350,7 @@ def user_subscription(
             config_format="v2ray",
             as_base64=True,
             reverse=False,
-            revoked=is_revoked,
+            revoked=is_revoked or is_expired,
             device_limited=device_limited,
             unsupported_client=unsupported_client
         )
@@ -386,22 +397,25 @@ def user_subscription_with_client_type(
     if not dbuser:
         return Response(status_code=404)
     crud.ensure_subscription_token(db, dbuser)
+    is_expired = bool(dbuser.expire and dbuser.expire > 0 and dbuser.expire < int(datetime.now(timezone.utc).timestamp()))
     user: UserResponse = UserResponse.model_validate(dbuser)
 
     device_limited = False
     unsupported_client = False
     registered = False
-    if not is_revoked:
+    if not is_revoked and not is_expired:
         registered, unsupported_client = crud.register_user_device(
             db, dbuser, x_hwid, x_device_os, x_ver_os, x_device_model, user_agent
         )
         device_limited = (not registered and not unsupported_client) or crud.is_device_limit_exceeded(db, dbuser)
-    if is_revoked or device_limited or unsupported_client:
+    if is_revoked or is_expired or device_limited or unsupported_client:
         user = get_empty_subscription_user(user)
 
     announce_text = get_user_note(user) or ""
     if is_revoked:
         announce_text = f"Подписка отозвана. Запросите новую ссылку в боте. {BOT_URL}"
+    elif is_expired:
+        announce_text = f"Подписка истекла. Продлите подписку в боте. {BOT_URL}"
     elif device_limited:
         announce_text = f"Достигнут лимит устройств. Удалите старое устройство или увеличьте лимит в боте. {BOT_URL}"
     elif unsupported_client:
@@ -425,7 +439,7 @@ def user_subscription_with_client_type(
                                  config_format=config["config_format"],
                                  as_base64=config["as_base64"],
                                  reverse=config["reverse"],
-                                 revoked=is_revoked,
+                                 revoked=is_revoked or is_expired,
                                  device_limited=device_limited,
                                  unsupported_client=unsupported_client)
 

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -103,16 +103,22 @@ def generate_subscription(
         as_base64: bool,
         reverse: bool,
         revoked: bool = False,
+        expired: bool = False,
         device_limited: bool = False,
         unsupported_client: bool = False,
 ) -> str:
+    from config import SUB_REVOKED_LINE1, SUB_REVOKED_LINE2, SUB_EXPIRED_LINE1, SUB_EXPIRED_LINE2
+
     # Special handling for inactive tokens: show two placeholder nodes for V2Ray
-    if config_format == "v2ray" and (revoked or device_limited or unsupported_client):
+    if config_format == "v2ray" and (revoked or expired or device_limited or unsupported_client):
         from app.subscription.v2ray import V2rayShareLink
 
         if revoked:
-            remark1 = "Эта ссылка не активна"
-            remark2 = "Обновите ссылку в боте"
+            remark1 = SUB_REVOKED_LINE1
+            remark2 = SUB_REVOKED_LINE2
+        elif expired:
+            remark1 = SUB_EXPIRED_LINE1
+            remark2 = SUB_EXPIRED_LINE2
         elif unsupported_client:
             remark1 = "Это приложение не поддерживается"
             remark2 = "Установите другое"

--- a/config.py
+++ b/config.py
@@ -138,6 +138,11 @@ SUB_PROFILE_TITLE = config("SUB_PROFILE_TITLE", default="Subscription")
 SUB_CLIENT_NOTE = config("SUB_CLIENT_NOTE", default="")
 BOT_URL = config("BOT_URL", default="")
 
+SUB_REVOKED_LINE1 = config("SUB_REVOKED_LINE1", default="Эта ссылка не активна")
+SUB_REVOKED_LINE2 = config("SUB_REVOKED_LINE2", default="Обновите ссылку в боте")
+SUB_EXPIRED_LINE1 = config("SUB_EXPIRED_LINE1", default="Подписка истекла")
+SUB_EXPIRED_LINE2 = config("SUB_EXPIRED_LINE2", default="Продлите подписку в боте")
+
 # discord webhook log
 DISCORD_WEBHOOK_URL = config("DISCORD_WEBHOOK_URL", default="")
 

--- a/templates/sub/expired.html
+++ b/templates/sub/expired.html
@@ -27,7 +27,7 @@
   <body class="antialiased">
     <main class="max-w-sm mx-auto p-4" style="width: 100%; max-width: 393px;">
       <div class="bg-gray-800 p-6 rounded-lg">
-        <div class="inline-block bg-yellow-900 text-yellow-200 rounded-full px-3 py-1 text-xs mb-3">Expired</div>
+        <div style="display:inline-block;background-color:#78350f;color:#fde68a;border-radius:9999px;padding:0.25rem 0.75rem;font-size:0.75rem;margin-bottom:0.75rem;">Expired</div>
         <h1 class="text-xl font-bold mb-2">Подписка истекла</h1>
         <p class="text-sm text-gray-400">
           Срок действия подписки закончился. Продлите подписку в боте:

--- a/templates/sub/expired.html
+++ b/templates/sub/expired.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Подписка истекла</title>
+    <link rel="stylesheet" href="/statics/main.css">
+    <link rel="icon" href="data:,">
+    <style>
+      body {
+        font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        background-color: #111827;
+        color: #e5e7eb;
+        margin: 0;
+        padding: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      .antialiased { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+      .max-w-sm { max-width: 24rem; }
+      .p-4 { padding: 1rem; }
+      .p-6 { padding: 1.5rem; }
+      .text-blue-400 { color: #60a5fa; }
+    </style>
+    <meta http-equiv="refresh" content="60">
+  </head>
+  <body class="antialiased">
+    <main class="max-w-sm mx-auto p-4" style="width: 100%; max-width: 393px;">
+      <div class="bg-gray-800 p-6 rounded-lg">
+        <div class="inline-block bg-yellow-900 text-yellow-200 rounded-full px-3 py-1 text-xs mb-3">Expired</div>
+        <h1 class="text-xl font-bold mb-2">Подписка истекла</h1>
+        <p class="text-sm text-gray-400">
+          Срок действия подписки закончился. Продлите подписку в боте:
+          <a href="{{ bot_url }}" class="text-blue-400 hover:underline">{{ bot_url }}</a>
+        </p>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
- При истёкшем expire подписка теперь отдаёт пустой конфиг (аналогично revoked), но с отдельными текстами и HTML-страницей, указывающими на возможность продления

- Добавлена новая HTML-страница templates/sub/expired.html

- Для Expired и Revoked подписок добавлена конфигурация через .env переменные: SUB_REVOKED_LINE1, SUB_REVOKED_LINE2, SUB_EXPIRED_LINE1, SUB_EXPIRED_LINE2