### PR TITLE
Background tasks optimization

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -61,6 +61,8 @@ def on_startup():
 @app.on_event("shutdown")
 def on_shutdown():
     scheduler.shutdown()
+    from app.utils.concurrency import shutdown_xray_executor
+    shutdown_xray_executor(wait=True)
 
 
 @app.exception_handler(RequestValidationError)

--- a/app/jobs/record_usages.py
+++ b/app/jobs/record_usages.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from operator import attrgetter
 from typing import Union
@@ -12,6 +11,7 @@ from sqlalchemy.sql.dml import Insert
 from app import scheduler, xray
 from app.db import GetDB
 from app.db.models import Admin, NodeUsage, NodeUserUsage, System, User
+from app.utils.concurrency import get_xray_executor
 from config import (
     DISABLE_RECORDING_NODE_USAGE,
     JOB_RECORD_NODE_USAGES_INTERVAL,
@@ -136,8 +136,8 @@ def record_user_usages():
             api_instances[node_id] = node.api
             usage_coefficient[node_id] = node.usage_coefficient  # fetch the usage coefficient
 
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {node_id: executor.submit(get_users_stats, api) for node_id, api in api_instances.items()}
+    executor = get_xray_executor()
+    futures = {node_id: executor.submit(get_users_stats, api) for node_id, api in api_instances.items()}
     api_params = {node_id: future.result() for node_id, future in futures.items()}
 
     users_usage = defaultdict(int)
@@ -189,8 +189,8 @@ def record_node_usages():
         if node.connected and node.started:
             api_instances[node_id] = node.api
 
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {node_id: executor.submit(get_outbounds_stats, api) for node_id, api in api_instances.items()}
+    executor = get_xray_executor()
+    futures = {node_id: executor.submit(get_outbounds_stats, api) for node_id, api in api_instances.items()}
     api_params = {node_id: future.result() for node_id, future in futures.items()}
 
     total_up = 0

--- a/app/jobs/reset_user_data_usage.py
+++ b/app/jobs/reset_user_data_usage.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from app import logger, scheduler, xray
-from app.db import crud, GetDB, get_users
+from app.db import GetDB, crud, get_users
 from app.models.user import UserDataLimitResetStrategy, UserStatus
 
 reset_strategy_to_days = {

--- a/app/jobs/review_users.py
+++ b/app/jobs/review_users.py
@@ -1,3 +1,4 @@
+from concurrent.futures import as_completed
 from datetime import datetime
 import time
 from typing import TYPE_CHECKING
@@ -9,6 +10,7 @@ from app.db import (GetDB, get_notification_reminder, get_users,
                     start_user_expire, update_user_status, reset_user_by_next)
 from app.models.user import ReminderType, UserResponse, UserStatus
 from app.utils import report
+from app.utils.concurrency import get_xray_executor
 from app.utils.helpers import (calculate_expiration_days,
                                calculate_usage_percent)
 from config import (JOB_REVIEW_USERS_INTERVAL, NOTIFY_DAYS_LEFT,
@@ -64,10 +66,9 @@ def review():
     now = datetime.utcnow()
     now_ts = now.timestamp()
     start_ts = time.time()
-    SLOW_USER_TOTAL_THRESHOLD = 1.0
-    SLOW_STEP_THRESHOLD = 0.3
     BATCH_SIZE_ACTIVE = 500
     BATCH_SIZE_ONHOLD = 500
+    REMOVE_BATCH_SIZE = 50
     checked_active = 0
     applied_next = 0
     limited_count = 0
@@ -86,11 +87,10 @@ def review():
             pass
 
         changed_in_batch = 0
+        # Collect users that need removal from xray for batch processing
+        users_to_remove = []
         for user in active_users:
             checked_active += 1
-            _u_t0 = time.time()
-            _t_remove = 0.0
-            _t_update_status = 0.0
 
             limited = user.data_limit and user.used_traffic >= user.data_limit
             expired = user.expire and user.expire <= now_ts
@@ -102,7 +102,7 @@ def review():
                         reset_user_by_next_report(db, user)
                         applied_next += 1
                         continue
-                        
+
                     elif limited and expired:
                         reset_user_by_next_report(db, user)
                         applied_next += 1
@@ -119,24 +119,13 @@ def review():
                     add_notification_reminders(db, user, now)
                 continue
 
-            # При недоступности XRAY-нод не допускаем падения задачи: статус все равно обновляем
-            _tr0 = time.time()
-            try:
-                xray.operations.remove_user(user)
-            except Exception as e:
-                logger.warning(f"Failed to remove user \"{user.username}\" from XRAY: {e}")
-            finally:
-                _t_remove = time.time() - _tr0
-
-            _ts0 = time.time()
+            users_to_remove.append(user)
             update_user_status(db, user, status, commit=False)
-            _t_update_status = time.time() - _ts0
 
             report.status_change(username=user.username, status=status,
                                  user=UserResponse.model_validate(user), user_admin=user.admin)
 
             logger.info(f"User \"{user.username}\" status changed to {status}")
-            _u_dur = time.time() - _u_t0
             changed_in_batch += 1
 
             # Commit batch periodically to avoid long-held locks
@@ -149,18 +138,28 @@ def review():
                 finally:
                     changed_in_batch = 0
 
-            if _u_dur >= SLOW_USER_TOTAL_THRESHOLD or _t_remove >= SLOW_STEP_THRESHOLD or _t_update_status >= SLOW_STEP_THRESHOLD:
-                logger.info(
-                    f"[review][active][slow] user=\"{user.username}\" total={_u_dur:.3f}s "
-                    f"remove_user={_t_remove:.3f}s update_status={_t_update_status:.3f}s"
-                )
-
-        # Коммитим все изменения статусов/next-планов за один раз
+        # Commit all status changes before removing from xray
         try:
             db.commit()
         except Exception as e:
             logger.error(f"Failed to commit batched review changes: {e}")
             raise
+
+        # Remove users from xray in batches through the thread pool
+        if users_to_remove:
+            executor = get_xray_executor()
+            _remove_t0 = time.time()
+            for batch_start in range(0, len(users_to_remove), REMOVE_BATCH_SIZE):
+                batch = users_to_remove[batch_start:batch_start + REMOVE_BATCH_SIZE]
+                futures = {executor.submit(xray.operations.remove_user, u): u for u in batch}
+                for future in as_completed(futures):
+                    u = futures[future]
+                    try:
+                        future.result()
+                    except Exception as e:
+                        logger.warning(f"Failed to remove user \"{u.username}\" from XRAY: {e}")
+            _remove_dur = time.time() - _remove_t0
+            logger.info(f"[review] removed {len(users_to_remove)} users from xray in {_remove_dur:.3f}s")
 
         _fetch_hold_t0 = time.time()
         on_hold_users = get_users(db, status=UserStatus.on_hold)

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -1,3 +1,4 @@
+from concurrent.futures import as_completed
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 from typing import List, Optional, Union
@@ -8,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from app import logger, xray
 from app.db import Session, crud, get_db
 from app.dependencies import get_expired_users_list, get_validated_user, validate_dates
+from app.utils.concurrency import get_xray_executor
 from app.models.admin import Admin
 from app.models.user import (
     UserCreate,
@@ -36,19 +38,35 @@ from app.models.proxy import (
 router = APIRouter(tags=["User"], prefix="/api", responses={401: responses._401})
 
 SYNC_PROGRESS = {}
+SYNC_BATCH_SIZE = 50
 
-def _run_update_and_mark(user_id: int, op_id: str):
-    """
-    Background helper to update user and mark progress counters.
-    """
-    try:
-        from app.db import GetDB
-        with GetDB() as db:
-            dbuser = crud.get_user_by_id(db, user_id)
-            if not dbuser:
-                return
+
+def _update_single_user(user_id: int) -> bool:
+    """Load user from DB and update on xray. Returns True on success."""
+    from app.db import GetDB
+    with GetDB() as db:
+        dbuser = crud.get_user_by_id(db, user_id)
+        if not dbuser:
+            return False
+        xray.operations.update_user(dbuser)
+        return True
+
+
+def _batch_sync_users(user_ids: list, op_id: str):
+    """Process user updates in batches through the global thread pool."""
+    executor = get_xray_executor()
+    total = len(user_ids)
+
+    for batch_start in range(0, total, SYNC_BATCH_SIZE):
+        batch = user_ids[batch_start:batch_start + SYNC_BATCH_SIZE]
+        futures = {executor.submit(_update_single_user, uid): uid for uid in batch}
+
+        for future in as_completed(futures):
+            uid = futures[future]
             try:
-                xray.operations.update_user(dbuser)
+                future.result()
+            except Exception as e:
+                logger.warning("[sync-inbounds] failed to update user_id=%d: %s", uid, e)
             finally:
                 try:
                     st = SYNC_PROGRESS.get(op_id)
@@ -59,17 +77,6 @@ def _run_update_and_mark(user_id: int, op_id: str):
                             st["finished_at"] = datetime.utcnow().isoformat()
                 except Exception:
                     pass
-    except Exception:
-        # ignore any exceptions to not break background runner, but still count as done
-        try:
-            st = SYNC_PROGRESS.get(op_id)
-            if st:
-                st["done"] = st.get("done", 0) + 1
-                if st["done"] >= st.get("scheduled", 0):
-                    st["running"] = False
-                    st["finished_at"] = datetime.utcnow().isoformat()
-        except Exception:
-            pass
 
 
 @router.post("/user", response_model=UserResponse, responses={400: responses._400, 409: responses._409})
@@ -393,7 +400,7 @@ def sync_users_inbounds(
     op_id = uuid4().hex
     users = crud.get_users(db=db, status=UserStatus.active)
     users_updated = 0
-    users_scheduled = 0
+    scheduled_user_ids = []
     SYNC_PROGRESS[op_id] = {
         "running": True,
         "started_at": datetime.utcnow().isoformat(),
@@ -467,14 +474,19 @@ def sync_users_inbounds(
         # Apply to running cores for active/on-hold users regardless of DB change,
         # so newly added/removed global inbounds reflect in runtime.
         if dbuser.status in [UserStatus.active, UserStatus.on_hold]:
-            users_scheduled += 1
-            SYNC_PROGRESS[op_id]["scheduled"] = users_scheduled
-            bg.add_task(_run_update_and_mark, user_id=dbuser.id, op_id=op_id)
+            scheduled_user_ids.append(dbuser.id)
             logger.info('[sync-inbounds] queued update_user for user="%s"', dbuser.username)
         SYNC_PROGRESS[op_id]["users_processed"] += 1
 
     if users_updated:
         db.commit()
+
+    users_scheduled = len(scheduled_user_ids)
+    SYNC_PROGRESS[op_id]["scheduled"] = users_scheduled
+
+    # Single background task handles all users in batches via the thread pool
+    if scheduled_user_ids:
+        bg.add_task(_batch_sync_users, user_ids=scheduled_user_ids, op_id=op_id)
 
     result = {
         "detail": "Inbounds synchronized with global configuration.",

--- a/app/utils/concurrency.py
+++ b/app/utils/concurrency.py
@@ -1,13 +1,33 @@
-from threading import Thread
+import logging
+from concurrent.futures import Future, ThreadPoolExecutor
 
 import anyio
 from fastapi import BackgroundTasks
 
+from config import XRAY_THREAD_POOL_SIZE
+
+logger = logging.getLogger("uvicorn.error")
+
+# Global thread pool for all xray operations (gRPC calls, node management, etc.)
+# Instead of spawning an unbounded number of threads, all work goes through this pool.
+_xray_executor = ThreadPoolExecutor(max_workers=XRAY_THREAD_POOL_SIZE, thread_name_prefix="xray-pool")
+
+
+def get_xray_executor() -> ThreadPoolExecutor:
+    return _xray_executor
+
+
+def shutdown_xray_executor(wait: bool = True):
+    logger.info("[concurrency] shutting down xray thread pool (wait=%s)", wait)
+    _xray_executor.shutdown(wait=wait)
+
 
 def threaded_function(func):
-    def wrapper(*args, **kwargs):
-        thread = Thread(target=func, args=args, daemon=True, kwargs=kwargs)
-        thread.start()
+    """Submit work to the global xray thread pool instead of spawning a new Thread per call.
+    Returns a Future (ignored by current callers, but available if needed)."""
+    def wrapper(*args, **kwargs) -> Future:
+        return _xray_executor.submit(func, *args, **kwargs)
+    wrapper.__wrapped__ = func
     return wrapper
 
 
@@ -23,7 +43,7 @@ class GetBG:
         return self.bg
 
     def __exit__(self, exc_type, exc_value, traceback):
-        Thread(target=anyio.run, args=(self.bg,), daemon=True).start()
+        _xray_executor.submit(anyio.run, self.bg)
 
     async def __aenter__(self):
         return self.bg

--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ XRAY_FALLBACKS_INBOUND_TAG = config("XRAY_FALLBACKS_INBOUND_TAG", cast=str, defa
 XRAY_EXECUTABLE_PATH = config("XRAY_EXECUTABLE_PATH", default="/usr/local/bin/xray")
 XRAY_ASSETS_PATH = config("XRAY_ASSETS_PATH", default="/usr/local/share/xray")
 XRAY_EXCLUDE_INBOUND_TAGS = config("XRAY_EXCLUDE_INBOUND_TAGS", default='').split()
+XRAY_THREAD_POOL_SIZE = config("XRAY_THREAD_POOL_SIZE", cast=int, default=20)
 XRAY_SUBSCRIPTION_URL_PREFIX = config("XRAY_SUBSCRIPTION_URL_PREFIX", default="").strip("/")
 XRAY_SUBSCRIPTION_PATH = config("XRAY_SUBSCRIPTION_PATH", default="sub").strip("/")
 


### PR DESCRIPTION
заменить неограниченное создание потоков на глобальный ThreadPoolExecutor

  @threaded_function создавал новый Thread на каждый gRPC-вызов без лимита,
  что приводило к взрыву потоков под нагрузкой (до 18к потоков при sync 1000
  пользователей). Заменено на пул фиксированного размера (XRAY_THREAD_POOL_SIZE,
  по умолчанию 20) — задачи сверх лимита встают в очередь.

  - concurrency.py: ThreadPoolExecutor вместо Thread на каждый вызов
  - config.py: настройка XRAY_THREAD_POOL_SIZE
  - app/__init__.py: корректное завершение пула при остановке приложения
  - user.py: батчевая обработка sync-inbounds через пул (по 50)
  - review_users.py: батчевый remove_user через пул (по 50)
  - record_usages.py: переиспользование глобального пула вместо создания нового на каждый вызов