### PR TITLE
NPVPN-970: exception logging middleware and persistent file logs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,12 +1,19 @@
 import logging
+import logging.handlers
+import os
+import time
+import traceback
+from pathlib import Path
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from config import ALLOWED_ORIGINS, DOCS, XRAY_SUBSCRIPTION_PATH
 
@@ -32,6 +39,46 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def log_exceptions_middleware(request: Request, call_next):
+    """
+    Логирует полный traceback любого необработанного исключения, которое
+    вылетает из роутеров/зависимостей, ДО того как Starlette превратит
+    его в 500 ответ. Нужен, чтобы в docker logs всегда появлялись
+    подробности причины 500, а не только строка access-лога.
+
+    HTTPException (в т.ч. 4xx/5xx намеренно брошенные роутерами) —
+    это контракт API, их trace не пишем, чтобы не шуметь.
+    Любой не-HTTP exception пробрасываем дальше неизменённым, чтобы
+    поведение для клиента не поменялось.
+    """
+    started_at = time.monotonic()
+    try:
+        return await call_next(request)
+    except (HTTPException, StarletteHTTPException):
+        raise
+    except Exception as exc:
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        client_host = request.client.host if request.client else "-"
+        user_agent = request.headers.get("user-agent", "-")
+        logger.error(
+            "Unhandled exception in %s %s?%s from %s ua=%r after %dms: "
+            "%s: %s\n%s",
+            request.method,
+            request.url.path,
+            request.url.query or "",
+            client_host,
+            user_agent,
+            duration_ms,
+            type(exc).__name__,
+            exc,
+            traceback.format_exc(),
+        )
+        raise
+
+
 from app import dashboard, jobs, routers, telegram  # noqa
 from app.routers import api_router  # noqa
 
@@ -47,6 +94,64 @@ def use_route_names_as_operation_ids(app: FastAPI) -> None:
 use_route_names_as_operation_ids(app)
 
 
+def _setup_file_logging() -> None:
+    """
+    Вешает RotatingFileHandler на uvicorn-loggers так, чтобы access-лог
+    и все traceback'и из log_exceptions_middleware писались на хостовой
+    том, смонтированный в /var/log/app (см. docker-compose.yaml сервиса
+    marzban). Это нужно, чтобы логи переживали recreate контейнера через
+    refresh.sh (json-file driver их стирает при удалении container id).
+
+    Вызывается из on_startup() — гарантированно ПОСЛЕ того как uvicorn
+    сконфигурировал свои loggers через log_config dictConfig, иначе наш
+    handler был бы затёрт.
+    """
+    log_dir = Path(os.getenv("LOG_DIR", "/var/log/app"))
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        logger.warning("Failed to create log dir %s: %s; file logging disabled", log_dir, e)
+        return
+
+    try:
+        max_bytes = int(os.getenv("LOG_FILE_MAX_SIZE_MB", "50")) * 1024 * 1024
+        backup_count = int(os.getenv("LOG_FILE_BACKUP_COUNT", "10"))
+    except ValueError:
+        max_bytes = 50 * 1024 * 1024
+        backup_count = 10
+
+    fmt = logging.Formatter(
+        fmt="%(asctime)s %(levelname)-8s %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # Один файл на оба канала — так проще искать трейсбеки рядом с access-логом.
+    handler = logging.handlers.RotatingFileHandler(
+        log_dir / "marzban.log",
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        encoding="utf-8",
+    )
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(fmt)
+
+    # Маркер, чтобы не добавлять handler дважды при горячей перезагрузке воркера.
+    handler._marzban_file_handler = True  # type: ignore[attr-defined]
+
+    for logger_name in ("uvicorn.error", "uvicorn.access"):
+        lg = logging.getLogger(logger_name)
+        if any(getattr(h, "_marzban_file_handler", False) for h in lg.handlers):
+            continue
+        lg.addHandler(handler)
+
+    logger.info(
+        "File logging enabled: %s (max=%dMB, backups=%d)",
+        log_dir / "marzban.log",
+        max_bytes // (1024 * 1024),
+        backup_count,
+    )
+
+
 @app.on_event("startup")
 def on_startup():
     paths = [f"{r.path}/" for r in app.routes]
@@ -55,6 +160,7 @@ def on_startup():
         raise ValueError(
             f"you can't use /{XRAY_SUBSCRIPTION_PATH}/ as subscription path it reserved for {app.title}"
         )
+    _setup_file_logging()
     scheduler.start()
 
 


### PR DESCRIPTION
## Summary

- Add a global HTTP middleware (`log_exceptions_middleware`) in `app/__init__.py` that logs the full traceback of any unhandled non-HTTPException, together with request method, path, query, client host, user-agent and duration, and then re-raises unchanged. HTTPException (4xx/5xx raised intentionally by routers) is treated as a contract response and is not logged, to avoid noise.
- Add `_setup_file_logging()` called from `on_startup()` to attach a `RotatingFileHandler` to `uvicorn.error` and `uvicorn.access` loggers, writing to `/var/log/app/marzban.log`. Called from `on_startup` so it runs after uvicorn's own `log_config` has been applied — otherwise the handler would be overwritten. File is capped at `LOG_FILE_MAX_SIZE_MB` (default 50MB) × `LOG_FILE_BACKUP_COUNT` (default 10) rotations.
- Companion PR in `telegram_bot` (NPVPN-970) mounts `./var/log/marzban_panel:/var/log/app` for the marzban service so these logs land on the host filesystem and survive container recreate from `refresh.sh` (json-file driver does not, it is tied to container id).

Motivation: during the 7 April incident we lost all panel logs because `refresh.sh vpn` runs `--force-recreate`, and the few logs that remained had no tracebacks because routers were swallowing exceptions into `HTTPException(500)`.

## Test plan

- [x] Middleware triggered by a synthetic `RuntimeError` route: full traceback appears in `docker logs nvb_marz` with method/path/client/ua/duration
- [x] `raise HTTPException(404)` still returns 404 to the client and does NOT log a traceback (HTTPException path)
- [x] File `/var/log/app/marzban.log` is created on startup; both `uvicorn.access` and `uvicorn.error` lines are written
- [x] File survives `docker compose up -d --build --force-recreate marzban` — both pre- and post-recreate records are visible in the same file
- [ ] After merge, host directory `var/log/marzban_panel` must be created on the prod host before first deploy of the new image