### PR TITLE
NPVPN-991: add prometheus-fastapi-instrumentator

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -79,6 +79,16 @@ async def log_exceptions_middleware(request: Request, call_next):
         raise
 
 
+from prometheus_fastapi_instrumentator import Instrumentator
+
+Instrumentator(
+    should_group_status_codes=False,
+    should_ignore_untemplated=True,
+    excluded_handlers=["/metrics"],
+    inprogress_name="http_requests_in_progress",
+    inprogress_labels=True,
+).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
+
 from app import dashboard, jobs, routers, telegram  # noqa
 from app.routers import api_router  # noqa
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ urllib3==1.26.19
 uvicorn==0.27.0.post1
 websocket-client==1.7.0
 websockets==12.0
+prometheus-fastapi-instrumentator==7.0.2


### PR DESCRIPTION
## Summary

- Add `prometheus-fastapi-instrumentator==7.0.2` dependency
- Expose `/metrics` endpoint with HTTP request metrics (`http_requests_total`, `http_request_duration_seconds`, `http_requests_in_progress`)
- Untemplated paths ignored to prevent cardinality explosion from scanners
- `/metrics` excluded from self-tracking and hidden from Swagger

## Test plan

- [ ] `curl http://nvb_marz:8001/metrics` returns Prometheus text format
- [ ] `/metrics` does not appear in `/docs`
- [ ] Scrape target + alert rules in npvpn/telegram_bot (separate PR)