### PR TITLE
NPVPN-1104: trace slow /api/user requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import logging.handlers
 import os
 import time
 import traceback
+from uuid import uuid4
 from pathlib import Path
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -16,6 +17,12 @@ from fastapi.routing import APIRoute
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from config import ALLOWED_ORIGINS, DOCS, XRAY_SUBSCRIPTION_PATH
+from app.utils.request_context import (
+    request_handler_var,
+    request_id_var,
+    request_method_var,
+    request_path_template_var,
+)
 
 __version__ = "0.8.4"
 
@@ -55,8 +62,54 @@ async def log_exceptions_middleware(request: Request, call_next):
     поведение для клиента не поменялось.
     """
     started_at = time.monotonic()
+    # Correlation id (comes from client or generated here)
+    rid = request.headers.get("x-request-id") or uuid4().hex
+    token_rid = request_id_var.set(rid)
+
+    # Best-effort handler + route template extraction for logs/SQL correlation
+    route = request.scope.get("route")
+    endpoint = request.scope.get("endpoint")
+    handler = None
+    path_template = None
     try:
-        return await call_next(request)
+        handler = getattr(endpoint, "__name__", None) if endpoint else None
+    except Exception:
+        handler = None
+    try:
+        path_template = getattr(route, "path", None) if route else None
+    except Exception:
+        path_template = None
+
+    token_method = request_method_var.set(getattr(request, "method", None))
+    token_path = request_path_template_var.set(path_template)
+    token_handler = request_handler_var.set(handler)
+
+    # Only log start/end for /api/user* to reduce noise
+    should_trace = False
+    try:
+        should_trace = bool(path_template and path_template.startswith("/api/user"))
+    except Exception:
+        should_trace = False
+
+    if should_trace:
+        client_host = request.client.host if request.client else "-"
+        logger.info(
+            "[http.start] rid=%s method=%s handler=%s path=%s tmpl=%s from=%s ua=%r",
+            rid,
+            request.method,
+            handler or "-",
+            request.url.path,
+            path_template or "-",
+            client_host,
+            request.headers.get("user-agent", "-"),
+        )
+    try:
+        response = await call_next(request)
+        try:
+            response.headers["X-Request-ID"] = rid
+        except Exception:
+            pass
+        return response
     except (HTTPException, StarletteHTTPException):
         raise
     except Exception as exc:
@@ -64,8 +117,10 @@ async def log_exceptions_middleware(request: Request, call_next):
         client_host = request.client.host if request.client else "-"
         user_agent = request.headers.get("user-agent", "-")
         logger.error(
-            "Unhandled exception in %s %s?%s from %s ua=%r after %dms: "
+            "Unhandled exception rid=%s handler=%s in %s %s?%s from %s ua=%r after %dms: "
             "%s: %s\n%s",
+            rid,
+            handler or "-",
             request.method,
             request.url.path,
             request.url.query or "",
@@ -77,6 +132,33 @@ async def log_exceptions_middleware(request: Request, call_next):
             traceback.format_exc(),
         )
         raise
+    finally:
+        try:
+            response_status = "-"
+            # response is only defined on success path
+            if "response" in locals():
+                response_status = str(getattr(locals()["response"], "status_code", "-"))
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            if should_trace:
+                logger.info(
+                    "[http.end] rid=%s method=%s handler=%s tmpl=%s status=%s dur_ms=%d",
+                    rid,
+                    request.method,
+                    handler or "-",
+                    path_template or "-",
+                    response_status,
+                    duration_ms,
+                )
+        except Exception:
+            pass
+        # Reset contextvars
+        try:
+            request_id_var.reset(token_rid)
+            request_method_var.reset(token_method)
+            request_path_template_var.reset(token_path)
+            request_handler_var.reset(token_handler)
+        except Exception:
+            pass
 
 
 from prometheus_fastapi_instrumentator import Instrumentator

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -2,6 +2,9 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from .base import Base, SessionLocal, engine  # noqa
+from app import logger
+from app.utils.request_context import request_id_var, request_handler_var
+import time
 
 
 class GetDB:  # Context Manager
@@ -9,6 +12,21 @@ class GetDB:  # Context Manager
         self.db = SessionLocal()
 
     def __enter__(self):
+        # Measure pool/connection checkout latency (helps detect DB stalls/locks/pool starvation)
+        _t0 = time.monotonic()
+        try:
+            # Force a real connection checkout early, so we can attribute wait time
+            self.db.connection()
+        finally:
+            waited_ms = int((time.monotonic() - _t0) * 1000)
+            # Log only if notable; threshold can be tuned via env later if needed
+            if waited_ms >= 200:
+                logger.warning(
+                    "[db.checkout.slow] rid=%s handler=%s waited_ms=%d",
+                    request_id_var.get() or "-",
+                    request_handler_var.get() or "-",
+                    waited_ms,
+                )
         # Apply per-session settings to reduce lock contention and long waits
         try:
             # Shorten lock wait to fail fast instead of hanging indefinitely

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,4 +1,7 @@
-from sqlalchemy import create_engine
+import os
+import time
+
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker, DeclarativeBase
 from config import (
     SQLALCHEMY_DATABASE_URL,
@@ -6,6 +9,8 @@ from config import (
     SQLALCHEMY_POOL_TIMEOUT,
     SQLIALCHEMY_MAX_OVERFLOW,
 )
+from app import logger
+from app.utils.request_context import snapshot
 
 IS_SQLITE = SQLALCHEMY_DATABASE_URL.startswith('sqlite')
 
@@ -24,6 +29,47 @@ else:
     )
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+_SLOW_SQL_MS = int(os.getenv("SLOW_SQL_MS", "200"))
+
+
+@event.listens_for(engine, "before_cursor_execute")
+def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+    try:
+        conn.info["query_start_time"] = time.monotonic()
+    except Exception:
+        pass
+
+
+@event.listens_for(engine, "after_cursor_execute")
+def _after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+    try:
+        started = conn.info.pop("query_start_time", None)
+        if started is None:
+            return
+        dur_ms = int((time.monotonic() - started) * 1000)
+        if dur_ms < _SLOW_SQL_MS:
+            return
+
+        ctx = snapshot()
+        # avoid huge logs: single-line & truncate
+        sql = " ".join(str(statement).split())
+        if len(sql) > 500:
+            sql = sql[:500] + "…"
+
+        logger.warning(
+            "[sql.slow] rid=%s method=%s handler=%s tmpl=%s dur_ms=%d sql=%r",
+            ctx.request_id or "-",
+            ctx.method or "-",
+            ctx.handler or "-",
+            ctx.path_template or "-",
+            dur_ms,
+            sql,
+        )
+    except Exception:
+        # Never break the query path because of logging
+        return
 
 
 class Base(DeclarativeBase):

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -1,10 +1,11 @@
 import threading
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+import time
 from uuid import uuid4
 from typing import List, Optional, Union
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
@@ -28,6 +29,7 @@ from app.models.user import (
     UserUsagesResponse,
 )
 from app.utils import report, responses
+from app.utils.request_context import request_id_var
 from app.db.models import Proxy as DBProxy
 from app.models.proxy import (
     ProxyTypes,
@@ -147,6 +149,7 @@ def _batch_sync_users(user_ids: list, op_id: str):
 def add_user(
     new_user: UserCreate,
     bg: BackgroundTasks,
+    request: Request,
     db: Session = Depends(get_db),
     admin: Admin = Depends(Admin.get_current),
 ):
@@ -176,9 +179,16 @@ def add_user(
             )
 
     try:
-        dbuser = crud.create_user(
-            db, new_user, admin=crud.get_admin(db, admin.username)
-        )
+        _t0 = time.monotonic()
+        dbuser = crud.create_user(db, new_user, admin=crud.get_admin(db, admin.username))
+        _dur_ms = int((time.monotonic() - _t0) * 1000)
+        if _dur_ms >= 500:
+            logger.warning(
+                "[user.add.slow] username=%s dur_ms=%d rid=%s",
+                getattr(dbuser, "username", "-"),
+                _dur_ms,
+                request_id_var.get() or "-",
+            )
     except IntegrityError:
         db.rollback()
         raise HTTPException(status_code=409, detail="User already exists")
@@ -191,10 +201,32 @@ def add_user(
 
 
 @router.get("/user/{username}", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
-def get_user(db: Session = Depends(get_db), dbuser: UserResponse = Depends(get_validated_user)):
+def get_user(
+    request: Request,
+    db: Session = Depends(get_db),
+    dbuser: UserResponse = Depends(get_validated_user),
+):
     """Get user information"""
+    _t0 = time.monotonic()
+    _t_ensure0 = time.monotonic()
     crud.ensure_subscription_token(db, dbuser)
-    return UserResponse.model_validate(dbuser)
+    _ensure_ms = int((time.monotonic() - _t_ensure0) * 1000)
+
+    _t_ser0 = time.monotonic()
+    resp = UserResponse.model_validate(dbuser)
+    _ser_ms = int((time.monotonic() - _t_ser0) * 1000)
+
+    _total_ms = int((time.monotonic() - _t0) * 1000)
+    if _total_ms >= 500 or _ensure_ms >= 200 or _ser_ms >= 200:
+        logger.warning(
+            "[user.get.slow] username=%s total_ms=%d ensure_ms=%d serialize_ms=%d rid=%s",
+            getattr(dbuser, "username", "-"),
+            _total_ms,
+            _ensure_ms,
+            _ser_ms,
+            request_id_var.get() or "-",
+        )
+    return resp
 
 
 @router.get(
@@ -273,6 +305,7 @@ def delete_user_device(
 def modify_user(
     modified_user: UserModify,
     bg: BackgroundTasks,
+    request: Request,
     db: Session = Depends(get_db),
     dbuser: UsersResponse = Depends(get_validated_user),
     admin: Admin = Depends(Admin.get_current),
@@ -303,7 +336,16 @@ def modify_user(
             )
 
     old_status = dbuser.status
+    _t0 = time.monotonic()
     dbuser = crud.update_user(db, dbuser, modified_user)
+    _dur_ms = int((time.monotonic() - _t0) * 1000)
+    if _dur_ms >= 500:
+        logger.warning(
+            "[user.modify.slow] username=%s dur_ms=%d rid=%s",
+            getattr(dbuser, "username", "-"),
+            _dur_ms,
+            request_id_var.get() or "-",
+        )
     user = UserResponse.model_validate(dbuser)
 
     if user.status in [UserStatus.active, UserStatus.on_hold]:
@@ -334,12 +376,22 @@ def modify_user(
 @router.delete("/user/{username}", responses={403: responses._403, 404: responses._404})
 def remove_user(
     bg: BackgroundTasks,
+    request: Request,
     db: Session = Depends(get_db),
     dbuser: UserResponse = Depends(get_validated_user),
     admin: Admin = Depends(Admin.get_current),
 ):
     """Remove a user"""
+    _t0 = time.monotonic()
     crud.remove_user(db, dbuser)
+    _dur_ms = int((time.monotonic() - _t0) * 1000)
+    if _dur_ms >= 500:
+        logger.warning(
+            "[user.delete.slow] username=%s dur_ms=%d rid=%s",
+            getattr(dbuser, "username", "-"),
+            _dur_ms,
+            request_id_var.get() or "-",
+        )
     bg.add_task(xray.operations.remove_user, dbuser=dbuser)
 
     bg.add_task(

--- a/app/utils/request_context.py
+++ b/app/utils/request_context.py
@@ -1,0 +1,28 @@
+import contextvars
+from dataclasses import dataclass
+
+
+request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("request_id", default=None)
+request_method_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("request_method", default=None)
+request_path_template_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_path_template", default=None
+)
+request_handler_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("request_handler", default=None)
+
+
+@dataclass(frozen=True)
+class RequestContextSnapshot:
+    request_id: str | None
+    method: str | None
+    path_template: str | None
+    handler: str | None
+
+
+def snapshot() -> RequestContextSnapshot:
+    return RequestContextSnapshot(
+        request_id=request_id_var.get(),
+        method=request_method_var.get(),
+        path_template=request_path_template_var.get(),
+        handler=request_handler_var.get(),
+    )
+


### PR DESCRIPTION
## Summary
- Add request_id correlation and response header for /api/user*.
- Log slow DB checkout and slow SQL with rid/method/handler.
- Add step-level timings in /api/user* handlers to pinpoint multi-minute spikes.

## Test plan
- Deploy to a high-load prod and wait for a spike.
- Use rid to correlate and identify whether time is spent in DB checkout, SQL, or response serialization.
