### PR TITLE
NPVPN-1170 expose db pool metrics for prometheus

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -184,6 +184,10 @@ Instrumentator(
     )
 ).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
 
+from app.utils.db_metrics import register as _register_db_metrics  # noqa: E402
+
+_register_db_metrics()
+
 from app import dashboard, jobs, routers, telegram  # noqa
 from app.routers import api_router  # noqa
 

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,8 +1,9 @@
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError, TimeoutError as SATimeoutError
 from sqlalchemy.orm import Session
 
 from .base import Base, SessionLocal, engine  # noqa
 from app import logger
+from app.utils.db_metrics import db_checkout_slow_total, db_checkout_timeout_total
 from app.utils.request_context import request_id_var, request_handler_var
 import time
 
@@ -17,10 +18,14 @@ class GetDB:  # Context Manager
         try:
             # Force a real connection checkout early, so we can attribute wait time
             self.db.connection()
+        except SATimeoutError:
+            db_checkout_timeout_total.inc()
+            raise
         finally:
             waited_ms = int((time.monotonic() - _t0) * 1000)
             # Log only if notable; threshold can be tuned via env later if needed
             if waited_ms >= 200:
+                db_checkout_slow_total.inc()
                 logger.warning(
                     "[db.checkout.slow] rid=%s handler=%s waited_ms=%d",
                     request_id_var.get() or "-",

--- a/app/utils/db_metrics.py
+++ b/app/utils/db_metrics.py
@@ -1,0 +1,80 @@
+"""SQLAlchemy QueuePool exporter for Prometheus.
+
+Exposes pool capacity/usage as gauges and counts slow/timed-out checkouts. Lets
+Grafana surface the symptom we hit in NPVPN-1170: pool fully used while MySQL
+itself was idle (real bottleneck was the starlette threadpool, but the pool
+metric is what visually screams first).
+"""
+from prometheus_client import REGISTRY, Counter
+from prometheus_client.core import GaugeMetricFamily
+
+from app import logger
+
+db_checkout_slow_total = Counter(
+    "db_checkout_slow_total",
+    "Number of DB session checkouts that waited longer than SLOW_SQL_MS",
+)
+db_checkout_timeout_total = Counter(
+    "db_checkout_timeout_total",
+    "Number of DB session checkouts that exceeded SQLALCHEMY_POOL_TIMEOUT",
+)
+
+
+class _DbPoolCollector:
+    """Reads engine.pool stats at each /metrics scrape — no background work."""
+
+    def collect(self):
+        try:
+            from app.db.base import engine
+        except Exception:
+            return
+        pool = getattr(engine, "pool", None)
+        if pool is None:
+            return
+
+        size = _safe_call(pool, "size")
+        checked_out = _safe_call(pool, "checkedout")
+        overflow = _safe_call(pool, "overflow")
+        checked_in = _safe_call(pool, "checkedin")
+        max_overflow = getattr(pool, "_max_overflow", None)
+
+        if size is not None:
+            yield GaugeMetricFamily("db_pool_size", "Configured pool_size", value=size)
+        if max_overflow is not None:
+            yield GaugeMetricFamily(
+                "db_pool_max_overflow", "Configured max_overflow", value=max_overflow
+            )
+        if checked_out is not None:
+            yield GaugeMetricFamily("db_pool_checkedout", "Connections currently in use", value=checked_out)
+        if overflow is not None:
+            yield GaugeMetricFamily(
+                "db_pool_overflow",
+                "Connections beyond pool_size (negative if not all spawned yet)",
+                value=overflow,
+            )
+        if checked_in is not None:
+            yield GaugeMetricFamily("db_pool_checkedin", "Idle connections in the pool", value=checked_in)
+
+
+def _safe_call(pool, name):
+    fn = getattr(pool, name, None)
+    if fn is None:
+        return None
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
+_registered = False
+
+
+def register():
+    global _registered
+    if _registered:
+        return
+    try:
+        REGISTRY.register(_DbPoolCollector())
+        _registered = True
+    except Exception as exc:
+        logger.warning("[metrics] failed to register db pool collector: %s", exc)


### PR DESCRIPTION
## Контекст

Часть разбора NPVPN-1170 (заморозка панели 2026-05-05 17:12–17:36 UTC). Это **observability-only** PR — деплоится на прод **до** PR с фиксом (#34), чтобы зафиксировать baseline DB pool во время рассылочных пиков `:12`/`:42` и эмпирически подтвердить, что фикс попадает в нужную точку.

## Что делает

Добавляет в `/metrics` SQLAlchemy pool stats и счётчики медленных/таймаут-чекаутов:

- `db_pool_size`, `db_pool_max_overflow` — конфигурация
- `db_pool_checkedout`, `db_pool_checkedin`, `db_pool_overflow` — текущая загрузка
- `db_checkout_slow_total` — Counter, инкремент при `waited_ms ≥ 200` (тот же порог, что и существующий лог `[db.checkout.slow]`)
- `db_checkout_timeout_total` — Counter на `SQLAlchemy TimeoutError` (он же «QueuePool limit reached»)

Custom collector читает `engine.pool` на каждый scrape `/metrics` — без фоновых тредов, без сайд-эффектов на горячий путь.

## Безопасность

- Чисто аддитивно: новый модуль `app/utils/db_metrics.py` + 1 импорт в `app/__init__.py` + try/except + counter inc в `GetDB.__enter__`.
- Ничего не меняется в логике checkout'а. Counter inc — атомарный, не лочит.
- При сбое регистрации collector'а — warning в лог, остальное приложение работает как раньше.

## После мерджа

- Прод задеплоить, дождаться 2-3 циклов рассылки `:12`/`:42`.
- В Grafana → Marzban HTTP → секция «DB Pool» (отдельный PR на бота: npvpn/telegram_bot#NPVPN-1170/db-pool-observability).
- Если в момент рассылки `db_pool_checkedout → capacity` — гипотеза подтверждена, мерджим #34 (фикс).
- Если pool остаётся пустым даже при инциденте — гипотеза не верна, разбор продолжается.

## Yougile

[NPVPN-1170](https://itbcg.yougile.com/team/9a0e05abf438/npvpn#NPVPN-1170)
