### PR TITLE
NPVPN-1393/fix unknown device, add record with user-agent

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -795,6 +795,40 @@ def revoke_user_device(db: Session, dbdevice: UserDevice) -> UserDevice:
     return dbdevice
 
 
+def _unknown_user_agents_match(stored: Optional[str], incoming: Optional[str]) -> bool:
+    def norm(v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        s = v.strip()
+        return s if s else None
+
+    stored_n = norm(stored)
+    incoming_n = norm(incoming)
+    if stored_n == "Неизвестно":
+        stored_n = None
+    if stored_n is None and incoming_n is None:
+        return True
+    if stored_n is None or incoming_n is None:
+        return stored_n == incoming_n
+    return stored_n == incoming_n
+
+
+def _update_unknown_device_metadata(
+    dbdevice: UserDevice,
+    device_os: Optional[str],
+    ver_os: Optional[str],
+    device_model: Optional[str],
+    user_agent: Optional[str],
+) -> None:
+    dbdevice.device_os = device_os or dbdevice.device_os
+    dbdevice.ver_os = ver_os or dbdevice.ver_os
+    dbdevice.device_model = device_model or dbdevice.device_model
+    dbdevice.user_agent = user_agent or dbdevice.user_agent
+    if dbdevice.status == "revoked":
+        dbdevice.status = "active"
+    dbdevice.last_seen = datetime.utcnow()
+
+
 def register_user_device(
     db: Session,
     dbuser: User,
@@ -805,14 +839,15 @@ def register_user_device(
     user_agent: Optional[str],
 ) -> tuple[bool, bool]:
     unknown_hwid = "Неизвестное устройство"
-    unknown_value = "Неизвестно"
     if not hwid:
         dbdevice = get_user_device_by_hwid(db, dbuser, unknown_hwid)
         if dbdevice:
-            if dbdevice.status == "revoked":
-                dbdevice.status = "active"
-                dbdevice.last_seen = datetime.utcnow()
+            if _unknown_user_agents_match(dbdevice.user_agent, user_agent):
+                _update_unknown_device_metadata(
+                    dbdevice, device_os, ver_os, device_model, user_agent
+                )
                 db.commit()
+                return True, False
             return False, True
         if dbuser.device_limit:
             current = count_user_devices(db, dbuser)
@@ -821,10 +856,10 @@ def register_user_device(
         dbdevice = UserDevice(
             user_id=dbuser.id,
             hwid=unknown_hwid,
-            device_os=unknown_value,
-            ver_os=unknown_value,
-            device_model=unknown_value,
-            user_agent=unknown_value,
+            device_os=device_os,
+            ver_os=ver_os,
+            device_model=device_model,
+            user_agent=user_agent,
             status="active",
         )
         db.add(dbdevice)

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -363,19 +363,7 @@ def user_subscription(
             conf = build_subscription("v2ray", True, False)
             return Response(content=conf, media_type="text/plain", headers=response_headers)
 
-    elif re.match(r'^INCY/', user_agent):
-        incy_needs_stub_format = (
-            is_revoked
-            or is_expired
-            or unsupported_blocks
-            or device_limited_hard_for_gen
-            or device_limited
-        )
-        if incy_needs_stub_format:
-            conf = build_subscription("v2ray-json", False, False)
-            return Response(content=conf, media_type="application/json", headers=response_headers)
-        conf = build_subscription("v2ray", True, False)
-        return Response(content=conf, media_type="text/plain", headers=response_headers)
+
 
     else:
         conf = build_subscription("v2ray", True, False)

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -363,7 +363,19 @@ def user_subscription(
             conf = build_subscription("v2ray", True, False)
             return Response(content=conf, media_type="text/plain", headers=response_headers)
 
-
+    elif re.match(r'^INCY/', user_agent):
+        incy_needs_stub_format = (
+            is_revoked
+            or is_expired
+            or unsupported_blocks
+            or device_limited_hard_for_gen
+            or device_limited
+        )
+        if incy_needs_stub_format:
+            conf = build_subscription("v2ray-json", False, False)
+            return Response(content=conf, media_type="application/json", headers=response_headers)
+        conf = build_subscription("v2ray", True, False)
+        return Response(content=conf, media_type="text/plain", headers=response_headers)
 
     else:
         conf = build_subscription("v2ray", True, False)

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -136,7 +136,7 @@ def resolve_device_limit_subscription_state(
         )
         hard_device_limited = not registered and not unsupported_client
         device_limited = hard_device_limited or crud.is_device_limit_exceeded(db, dbuser)
-    unsupported_blocks = unsupported_client and bool(dbuser.device_limit)
+    unsupported_blocks = unsupported_client
     hard_mode = bool(bot_settings.get("sub_device_limit_hard_mode"))
     if (
         is_revoked

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import random
 import secrets
 from collections import defaultdict
@@ -98,71 +97,6 @@ def generate_v2ray_json_subscription(
     )
 
 
-_STUB_ZERO_ID = "00000000-0000-0000-0000-000000000000"
-_STUB_CONFIG_FORMATS = ("v2ray", "v2ray-json")
-
-
-def _is_full_inactive_subscription(
-        revoked: bool,
-        expired: bool,
-        unsupported_client: bool,
-        device_limited_hard: bool,
-) -> bool:
-    return revoked or expired or unsupported_client or device_limited_hard
-
-
-def _inactive_server_text_list(
-        resolved_settings: dict,
-        revoked: bool,
-        expired: bool,
-        device_limited_hard: bool,
-) -> list:
-    if revoked:
-        return resolved_settings["sub_revoked_server_text"]
-    if expired:
-        return resolved_settings["sub_expired_server_text"]
-    if device_limited_hard:
-        return resolved_settings["sub_device_limit_server_text"]
-    return resolved_settings["sub_unsupported_client_server_text"]
-
-
-def _generate_v2ray_stub_links(text_list: list) -> list:
-    return [
-        V2rayShareLink.vless(
-            remark=remark,
-            address="0.0.0.0",
-            port=0,
-            id=_STUB_ZERO_ID,
-            net="ws",
-            tls="none",
-            path="",
-            host="",
-        )
-        for remark in text_list
-    ]
-
-
-def generate_v2ray_json_placeholder_subscription(text_list: list) -> str:
-    conf = V2rayJsonConfig()
-    for remark in text_list:
-        outbound = {
-            "tag": "proxy",
-            "protocol": "vless",
-            "settings": V2rayJsonConfig.vless_config(
-                address="0.0.0.0",
-                port=0,
-                id=_STUB_ZERO_ID,
-            ),
-            "streamSettings": {
-                "network": "ws",
-                "security": "none",
-                "wsSettings": {},
-            },
-        }
-        conf.add_config(remarks=remark, outbounds=[outbound])
-    return conf.render()
-
-
 def generate_subscription(
         user: "UserResponse",
         config_format: Literal["v2ray", "clash-meta", "clash", "sing-box", "outline", "v2ray-json"],
@@ -179,35 +113,59 @@ def generate_subscription(
 
     resolved_settings = apply_bot_settings_fallback(settings or DEFAULT_BOT_SETTINGS)
 
-    if (
-        config_format in _STUB_CONFIG_FORMATS
-        and _is_full_inactive_subscription(
-            revoked, expired, unsupported_client, device_limited_hard
-        )
-    ):
-        text_list = _inactive_server_text_list(
-            resolved_settings, revoked, expired, device_limited_hard
-        )
+    # Special handling for inactive tokens: placeholder nodes for V2Ray
+    if config_format == "v2ray" and (revoked or expired or unsupported_client or device_limited_hard):
+        from app.subscription.v2ray import V2rayShareLink
+
+        if revoked:
+            text_list = resolved_settings["sub_revoked_server_text"]
+        elif expired:
+            text_list = resolved_settings["sub_expired_server_text"]
+        elif device_limited_hard:
+            text_list = resolved_settings["sub_device_limit_server_text"]
+        else:
+            text_list = resolved_settings["sub_unsupported_client_server_text"]
+
         if not text_list:
-            if config_format == "v2ray-json":
-                return "[]"
             return base64.b64encode("".encode()).decode()
-        if config_format == "v2ray-json":
-            return generate_v2ray_json_placeholder_subscription(text_list)
-        payload = "\n".join(_generate_v2ray_stub_links(text_list))
+
+        zero_id = "00000000-0000-0000-0000-000000000000"
+        links = [
+            V2rayShareLink.vless(
+                remark=remark,
+                address="0.0.0.0",
+                port=0,
+                id=zero_id,
+                net="ws",
+                tls="none",
+                path="",
+                host="",
+            )
+            for remark in text_list
+        ]
+        payload = "\n".join(links)
         return base64.b64encode(payload.encode()).decode()
 
     device_limit_links = []
-    device_limit_json_configs = []
-    if device_limited and not device_limited_hard:
+    if config_format == "v2ray" and device_limited and not device_limited_hard:
+        from app.subscription.v2ray import V2rayShareLink
+
         device_limit_text = resolved_settings["sub_device_limit_server_text"]
         if device_limit_text:
-            if config_format == "v2ray":
-                device_limit_links = _generate_v2ray_stub_links(device_limit_text)
-            elif config_format == "v2ray-json":
-                device_limit_json_configs = json.loads(
-                    generate_v2ray_json_placeholder_subscription(device_limit_text)
+            zero_id = "00000000-0000-0000-0000-000000000000"
+            device_limit_links = [
+                V2rayShareLink.vless(
+                    remark=remark,
+                    address="0.0.0.0",
+                    port=0,
+                    id=zero_id,
+                    net="ws",
+                    tls="none",
+                    path="",
+                    host="",
                 )
+                for remark in device_limit_text
+            ]
 
     kwargs = {
         "proxies": user.proxies,
@@ -231,15 +189,6 @@ def generate_subscription(
         config = generate_outline_subscription(**kwargs)
     elif config_format == "v2ray-json":
         config = generate_v2ray_json_subscription(**kwargs)
-        if device_limit_json_configs:
-            from app.utils.helpers import UUIDEncoder
-
-            main_configs = json.loads(config)
-            config = json.dumps(
-                device_limit_json_configs + main_configs,
-                indent=4,
-                cls=UUIDEncoder,
-            )
     else:
         raise ValueError(f'Unsupported format "{config_format}"')
 

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import random
 import secrets
 from collections import defaultdict
@@ -97,6 +98,71 @@ def generate_v2ray_json_subscription(
     )
 
 
+_STUB_ZERO_ID = "00000000-0000-0000-0000-000000000000"
+_STUB_CONFIG_FORMATS = ("v2ray", "v2ray-json")
+
+
+def _is_full_inactive_subscription(
+        revoked: bool,
+        expired: bool,
+        unsupported_client: bool,
+        device_limited_hard: bool,
+) -> bool:
+    return revoked or expired or unsupported_client or device_limited_hard
+
+
+def _inactive_server_text_list(
+        resolved_settings: dict,
+        revoked: bool,
+        expired: bool,
+        device_limited_hard: bool,
+) -> list:
+    if revoked:
+        return resolved_settings["sub_revoked_server_text"]
+    if expired:
+        return resolved_settings["sub_expired_server_text"]
+    if device_limited_hard:
+        return resolved_settings["sub_device_limit_server_text"]
+    return resolved_settings["sub_unsupported_client_server_text"]
+
+
+def _generate_v2ray_stub_links(text_list: list) -> list:
+    return [
+        V2rayShareLink.vless(
+            remark=remark,
+            address="0.0.0.0",
+            port=0,
+            id=_STUB_ZERO_ID,
+            net="ws",
+            tls="none",
+            path="",
+            host="",
+        )
+        for remark in text_list
+    ]
+
+
+def generate_v2ray_json_placeholder_subscription(text_list: list) -> str:
+    conf = V2rayJsonConfig()
+    for remark in text_list:
+        outbound = {
+            "tag": "proxy",
+            "protocol": "vless",
+            "settings": V2rayJsonConfig.vless_config(
+                address="0.0.0.0",
+                port=0,
+                id=_STUB_ZERO_ID,
+            ),
+            "streamSettings": {
+                "network": "ws",
+                "security": "none",
+                "wsSettings": {},
+            },
+        }
+        conf.add_config(remarks=remark, outbounds=[outbound])
+    return conf.render()
+
+
 def generate_subscription(
         user: "UserResponse",
         config_format: Literal["v2ray", "clash-meta", "clash", "sing-box", "outline", "v2ray-json"],
@@ -113,59 +179,35 @@ def generate_subscription(
 
     resolved_settings = apply_bot_settings_fallback(settings or DEFAULT_BOT_SETTINGS)
 
-    # Special handling for inactive tokens: placeholder nodes for V2Ray
-    if config_format == "v2ray" and (revoked or expired or unsupported_client or device_limited_hard):
-        from app.subscription.v2ray import V2rayShareLink
-
-        if revoked:
-            text_list = resolved_settings["sub_revoked_server_text"]
-        elif expired:
-            text_list = resolved_settings["sub_expired_server_text"]
-        elif device_limited_hard:
-            text_list = resolved_settings["sub_device_limit_server_text"]
-        else:
-            text_list = resolved_settings["sub_unsupported_client_server_text"]
-
+    if (
+        config_format in _STUB_CONFIG_FORMATS
+        and _is_full_inactive_subscription(
+            revoked, expired, unsupported_client, device_limited_hard
+        )
+    ):
+        text_list = _inactive_server_text_list(
+            resolved_settings, revoked, expired, device_limited_hard
+        )
         if not text_list:
+            if config_format == "v2ray-json":
+                return "[]"
             return base64.b64encode("".encode()).decode()
-
-        zero_id = "00000000-0000-0000-0000-000000000000"
-        links = [
-            V2rayShareLink.vless(
-                remark=remark,
-                address="0.0.0.0",
-                port=0,
-                id=zero_id,
-                net="ws",
-                tls="none",
-                path="",
-                host="",
-            )
-            for remark in text_list
-        ]
-        payload = "\n".join(links)
+        if config_format == "v2ray-json":
+            return generate_v2ray_json_placeholder_subscription(text_list)
+        payload = "\n".join(_generate_v2ray_stub_links(text_list))
         return base64.b64encode(payload.encode()).decode()
 
     device_limit_links = []
-    if config_format == "v2ray" and device_limited and not device_limited_hard:
-        from app.subscription.v2ray import V2rayShareLink
-
+    device_limit_json_configs = []
+    if device_limited and not device_limited_hard:
         device_limit_text = resolved_settings["sub_device_limit_server_text"]
         if device_limit_text:
-            zero_id = "00000000-0000-0000-0000-000000000000"
-            device_limit_links = [
-                V2rayShareLink.vless(
-                    remark=remark,
-                    address="0.0.0.0",
-                    port=0,
-                    id=zero_id,
-                    net="ws",
-                    tls="none",
-                    path="",
-                    host="",
+            if config_format == "v2ray":
+                device_limit_links = _generate_v2ray_stub_links(device_limit_text)
+            elif config_format == "v2ray-json":
+                device_limit_json_configs = json.loads(
+                    generate_v2ray_json_placeholder_subscription(device_limit_text)
                 )
-                for remark in device_limit_text
-            ]
 
     kwargs = {
         "proxies": user.proxies,
@@ -189,6 +231,15 @@ def generate_subscription(
         config = generate_outline_subscription(**kwargs)
     elif config_format == "v2ray-json":
         config = generate_v2ray_json_subscription(**kwargs)
+        if device_limit_json_configs:
+            from app.utils.helpers import UUIDEncoder
+
+            main_configs = json.loads(config)
+            config = json.dumps(
+                device_limit_json_configs + main_configs,
+                indent=4,
+                cls=UUIDEncoder,
+            )
     else:
         raise ValueError(f'Unsupported format "{config_format}"')
 


### PR DESCRIPTION
### Проблема
Клиенты без HWID (Hiddify, INCY и др.) используют один слот hwid = "Неизвестное устройство". Было три бага:

1. в БД писалось "Неизвестно" вместо реальных заголовков;

2. повторное обновление подписки на том же клиенте блокировалось как «второе устройство»;

3. второй неизвестный клиент с другим UA проходил, если у пользователя не был задан device_limit.

### Что сделано
crud.py — при создании сохраняются переданные device_os, user_agent и т.д. При повторном запросе без HWID сравнивается user_agent: тот же — обновление и выдача подписки, другой — unsupported_client. Старые записи с user_agent = "Неизвестно" при первом визите с реальным UA обновляются, не блокируются.

subscription.py — блокировка второго неизвестного клиента срабатывает всегда, без привязки к device_limit.

Результат
Одно неизвестное приложение на пользователя; повторные обновления на нём работают; устройства с нормальным HWID не затронуты.
