### PR TITLE
NPVPN-1491/delete cache, return check xray in health check

### DIFF
--- a/app/jobs/0_xray_core.py
+++ b/app/jobs/0_xray_core.py
@@ -4,6 +4,7 @@ import traceback
 from app import app, logger, scheduler, xray
 from app.db import GetDB, crud
 from app.models.node import NodeStatus
+from app.xray.node import NodeAPIError
 from config import (
     JOB_CORE_HEALTH_CHECK_INTERVAL,
     XRAY_NODE_ERROR_RECONNECT_INTERVAL,
@@ -12,18 +13,6 @@ from config import (
 from xray_api import exc as xray_exc
 
 _error_reconnect_last: dict[int, float] = {}
-
-
-def _quick_node_ready(node) -> bool:
-    """Cached readiness check — no network I/O."""
-    try:
-        if hasattr(node, "_session_id"):
-            return bool(getattr(node, "_session_id", None)) and bool(getattr(node, "_started", False))
-        if hasattr(node, "started"):
-            return bool(getattr(node, "started", False))
-    except Exception:
-        pass
-    return False
 
 
 def _should_force_reconnect(node_id: int, status: NodeStatus, now: float) -> bool:
@@ -62,10 +51,23 @@ def core_health_check():
 
         node = xray.nodes[node_id]
 
-        if dbnode.status == NodeStatus.connected and _quick_node_ready(node):
+        if dbnode.status == NodeStatus.connected:
+            if not node.connected:
+                if reconnects_scheduled >= max_reconnects:
+                    continue
+                if not config:
+                    config = xray.config.include_db_users()
+                xray.operations.connect_node(node_id, config)
+                reconnects_scheduled += 1
+                continue
+
             try:
+                # Must hit the node REST API (GET /), not cached _started — ping alone
+                # does not prove Xray is running (e.g. OOM killed the core).
+                if not node.started:
+                    raise AssertionError("Xray core is not started on node")
                 node.api.get_sys_stats(timeout=2)
-            except (ConnectionError, xray_exc.XrayError, AssertionError):
+            except (ConnectionError, NodeAPIError, xray_exc.XrayError, AssertionError):
                 if not config:
                     config = xray.config.include_db_users()
                 xray.operations.restart_node(node_id, config)
@@ -74,8 +76,7 @@ def core_health_check():
         if dbnode.status == NodeStatus.connecting:
             if xray.operations.is_connect_in_progress(node_id):
                 continue
-            if not xray.operations.is_connect_stale(node_id):
-                continue
+            # No active connect task — fall through and schedule reconnect below.
 
         if dbnode.status not in (NodeStatus.error, NodeStatus.connecting):
             continue

--- a/app/xray/node.py
+++ b/app/xray/node.py
@@ -250,7 +250,11 @@ class ReSTXRayNode:
     @property
     def started(self):
         res = self.make_request("/", timeout=XRAY_NODE_REST_INFO_TIMEOUT)
-        return res.get('started', False)
+        remote_started = res.get('started', False)
+        self._started = remote_started
+        if not remote_started:
+            self._close_grpc_api()
+        return remote_started
 
     @property
     def api(self):


### PR DESCRIPTION
## Что и зачем

После оптимизаций подключений нод (v1.0.26, коммит `97be57b`) health check перестал
проверять реальное состояние Xray на ноде: вместо сетевого `node.started` (GET `/`) использовался
кэш `_quick_node_ready` (`_session_id` + `_started` в памяти панели). При падении процесса Xray
(OOM и т.п.) REST API ноды продолжает отвечать на ping, статус в БД остаётся `connected`, а
переподключение не запускается.

Воспроизведено вручную: `kill -9` xray на ноде с `network_mode: host` → на ноде
`started: false`, `session_id: None`, в дашборде `connected`, в логах панели — тишина.

## Изменения

- `core_health_check`: для нод со статусом `connected` в БД восстановлена проверка через
  `node.connected` и `node.started` (сеть), затем `get_sys_stats`; при потере сессии —
  `connect_node`, при мёртвом Xray — `restart_node`
- убран `_quick_node_ready` из health check (кэш не отражает состояние remote core)
- исправлено зависание в `connecting`: если connect-задача не идёт, планируется reconnect
- `ReSTXRayNode.started`: синхронизация `_started` с ответом ноды и закрытие stale gRPC
- в except health check добавлен `NodeAPIError`

## Заметки для ревью

- Для `connected` в БД health check снова делает 1–2 HTTP-запроса на ноду за цикл (~10 с) —
  осознанный trade-off ради корректности; `_get_ready_nodes()` в operations.py по-прежнему на кэше
- Ручная проверка: убить xray (`kill -9 $(pgrep -f 'xray run')`), через ~10–20 с в логах панели
  ожидается `Connecting to` / `Restarting Xray core`, xray поднимается без ручного disable/enable