### PR TITLE
build: mypy pre-commit без инкрементального кэша (--no-incremental)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,9 @@ repos:
     hooks:
       - id: mypy-baseline
         name: mypy (baseline)
-        entry: bash -c 'uv run mypy app | uv run mypy-baseline filter'
+        # --no-incremental: гоняем без .mypy_cache, чтобы локальный хук всегда совпадал
+        # с чистым прогоном в CI (инкрементальный кэш + pydantic «уплывает» → ложные new/fixed).
+        entry: bash -c 'uv run mypy --no-incremental app | uv run mypy-baseline filter'
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
## Зачем

После фазы 0 локальный pre-commit-хук `mypy (baseline)` периодически краснел при зелёном CI: при правке pydantic-моделей инкрементальный `.mypy_cache` даёт ошибки в иной форме, чем чистый прогон, и `mypy-baseline filter` ловит ложные `new/fixed` (наблюдали 118 и 68/70 на разных ветках).

## Что

Хук теперь гоняет `uv run mypy --no-incremental app` — без кэша, как чистый чекаут в CI. Дрейфа больше не будет.

## Цена

~5 с на коммит вместо ~0.3 с (инкрементальный). CI не меняется — он и так стартует с чистого чекаута.

## Альтернатива (отклонена)

Чистить `.mypy_cache` руками при сбое — ненадёжно, бьёт по всем, кто трогает роутеры/модели.