### PR TITLE
NPVPN-1516: дефолтный VLESS flow xtls-rprx-vision при создании пользователя через интерфейс

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -140,7 +140,7 @@ const getDefaultValues = (): FormType => {
     bot_username: "",
     inbounds,
     proxies: {
-      vless: { id: "", flow: "" },
+      vless: { id: "", flow: "xtls-rprx-vision" },
       vmess: { id: "" },
       trojan: { password: "" },
       shadowsocks: { password: "", method: "chacha20-ietf-poly1305" },


### PR DESCRIPTION
## Что и зачем

При создании пользователя через веб-интерфейс панели VLESS `flow` по умолчанию был пустым (`XTLSFlows.NONE`). Теперь по умолчанию подставляется `xtls-rprx-vision`, чтобы новые пользователи сразу создавались с нужным flow без ручного выбора.

## Изменения

- `app/dashboard/src/components/UserDialog.tsx`: в `getDefaultValues()` дефолт `proxies.vless.flow` изменён с `""` на `"xtls-rprx-vision"`.

## Заметки для ревью

- Затрагивает **только создание через интерфейс**. Создание по API (`POST /api/user`) не меняется — бэкенд-дефолт `VLESSSettings.flow = XTLSFlows.NONE` (`app/models/proxy.py`) оставлен как есть.
- Редактирование пользователя не ломается: форма заполняется через `formatUser(editingUser)` (сохраняет существующий flow), а не через `getDefaultValues()`.
- `xtls-rprx-vision` — валидное значение enum `XTLSFlows.VISION` (`xray_api/types/account.py`).
- Билд dashboard не трекается в git и собирается из исходников в Docker (stage `frontend`, `npm run build`) — отдельной пересборки билда не требуется.