### PR TITLE
fix: device removal (add fetch from service/http)

### DIFF
--- a/app/dashboard/src/components/DevicesModal.tsx
+++ b/app/dashboard/src/components/DevicesModal.tsx
@@ -10,20 +10,19 @@ import {
   Text,
   Tooltip,
   VStack,
-  HStack,
   Accordion,
   AccordionItem,
   AccordionButton,
   AccordionPanel,
   AccordionIcon,
   Divider,
-  Box,
 } from "@chakra-ui/react";
 
 import { TrashIcon } from "@heroicons/react/24/outline";
 import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 import { User, UserDevice } from "types/User";
+import { fetch } from "service/http";
 
 const DeleteDeviceIcon = chakra(TrashIcon, {
   baseStyle: {

--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -34,7 +34,6 @@ import {
 import {
   ChartPieIcon,
   PencilIcon,
-  TrashIcon,
   UserPlusIcon,
 } from "@heroicons/react/24/outline";
 import { zodResolver } from "@hookform/resolvers/zod";


### PR DESCRIPTION
Добавила **import { fetch } from "service/http"** в модалку устройств DevicesModal
До фикса использовался глобальный window.fetch, который не прокидывал baseUrl и параметры, поэтому удаление устройств на сервере не происходило

- [ ] удаление устройства происходит корректно, после рефреша не отображается
