### PR TITLE
NPVPN-1585: ленивый рендер попапа выбора нод в хостах

### DIFF
--- a/app/dashboard/src/components/AccordionInbound.tsx
+++ b/app/dashboard/src/components/AccordionInbound.tsx
@@ -2,26 +2,17 @@ import {
   AccordionButton,
   AccordionIcon,
   AccordionItem,
-  AccordionPanel,
-  Button,
   Text,
-  VStack,
 } from "@chakra-ui/react";
-import React, { FC, useCallback, useEffect, useMemo } from "react";
-import { useFieldArray, useFormContext } from "react-hook-form";
-import { useTranslation } from "react-i18next";
+import React, { FC, useEffect, useMemo } from "react";
+import { useFormContext } from "react-hook-form";
 import "slick-carousel/slick/slick.css";
 import { Bot } from "types/Bot";
 import { z } from "zod";
 import { useDashboard } from "../contexts/DashboardContext";
 import { NodeType } from "../contexts/NodesContext";
 import { hostsSchema } from "./hostsDialog/schema";
-import { HostRow } from "./hostsDialog/HostRow";
-import {
-  proxyALPN,
-  proxyFingerprint,
-  proxyHostSecurity,
-} from "constants/Proxies";
+import { AccordionInboundContent } from "./hostsDialog/AccordionInboundContent";
 
 type AccordionInboundType = {
   hostKey: string;
@@ -31,87 +22,27 @@ type AccordionInboundType = {
   toggleAccordion: () => void;
 };
 
-const EMPTY_HOST = {
-  host: "",
-  sni: "",
-  port: null,
-  path: null,
-  address: "",
-  remark: "",
-  mux_enable: false,
-  allowinsecure: false,
-  is_disabled: false,
-  fragment_setting: "",
-  noise_setting: "",
-  random_user_agent: false,
-  security: "inbound_default",
-  alpn: "",
-  fingerprint: "",
-  use_sni_as_host: false,
-  bot_usernames: [],
-  node_ids: [],
-};
-
 export const AccordionInbound: FC<AccordionInboundType> = React.memo(
   ({ hostKey, isOpen, bots, nodes, toggleAccordion }) => {
     const { inbounds } = useDashboard();
 
-    const inbound = Array.from(inbounds.values())
-      .flat()
-      .find((i) => i.tag === hostKey);
+    const inbound = useMemo(
+      () =>
+        Array.from(inbounds.values())
+          .flat()
+          .find((i) => i.tag === hostKey),
+      [inbounds, hostKey]
+    );
 
     const form = useFormContext<z.infer<typeof hostsSchema>>();
-    const {
-      fields: hosts,
-      append: addHost,
-      remove: removeHost,
-      insert: insertHost,
-      move: moveHost,
-    } = useFieldArray({
-      control: form.control,
-      name: hostKey,
-    });
-
     const { errors } = form.formState;
-    const { t } = useTranslation();
     const accordionErrors = errors[hostKey];
-
-    const handleAddHost = useCallback(() => {
-      addHost(EMPTY_HOST);
-    }, [addHost]);
-
-    const duplicateHost = useCallback(
-      (index: number) => {
-        const value = form.getValues(`${hostKey}.${index}`);
-        if (!value) return;
-        insertHost(index + 1, structuredClone(value));
-      },
-      [form, insertHost, hostKey]
-    );
 
     useEffect(() => {
       if (accordionErrors && !isOpen) {
         toggleAccordion();
       }
     }, [accordionErrors, isOpen, toggleAccordion]);
-
-    const moveHostPosition = useCallback(
-      (index: number, direction: "up" | "down") => {
-        if (direction === "up" && index > 0) {
-          moveHost(index, index - 1);
-        } else if (direction === "down" && index < hosts.length - 1) {
-          moveHost(index, index + 1);
-        }
-      },
-      [moveHost, hosts.length]
-    );
-
-    const removeHostCallback = useCallback(
-      (index: number) => {
-        removeHost(index);
-      },
-      [removeHost]
-    );
 
     return (
       <AccordionItem
@@ -137,44 +68,13 @@ export const AccordionInbound: FC<AccordionInboundType> = React.memo(
           <AccordionIcon />
         </AccordionButton>
         {isOpen && (
-          <AccordionPanel px={2} pb={2}>
-            <VStack gap={3}>
-              {hosts.map((host, index) => (
-                <HostRow
-                  key={host.id}
-                  hostId={host.id}
-                  hostKey={hostKey}
-                  index={index}
-                  hostsLength={hosts.length}
-                  duplicateHost={duplicateHost}
-                  moveHostPosition={moveHostPosition}
-                  removeHost={removeHostCallback}
-                  bots={bots}
-                  nodes={nodes}
-                  inbound={inbound}
-                  inboundPort={inbound?.port}
-                  accordionErrors={accordionErrors}
-                  register={form.register}
-                  control={form.control}
-                  proxyHostSecurity={proxyHostSecurity}
-                  proxyALPN={proxyALPN}
-                  proxyFingerprint={proxyFingerprint}
-                  t={t}
-                />
-              ))}
-
-              <Button
-                variant="outline"
-                type="button"
-                w="full"
-                size="sm"
-                fontWeight="normal"
-                onClick={handleAddHost}
-              >
-                {t("hostsDialog.addHost")}
-              </Button>
-            </VStack>
-          </AccordionPanel>
+          <AccordionInboundContent
+            hostKey={hostKey}
+            bots={bots}
+            nodes={nodes}
+            inbound={inbound}
+            accordionErrors={accordionErrors}
+          />
         )}
       </AccordionItem>
     );

--- a/app/dashboard/src/components/AccordionInbound.tsx
+++ b/app/dashboard/src/components/AccordionInbound.tsx
@@ -9,7 +9,7 @@ import { useFormContext } from "react-hook-form";
 import "slick-carousel/slick/slick.css";
 import { Bot } from "types/Bot";
 import { z } from "zod";
-import { useDashboard } from "../contexts/DashboardContext";
+import { InboundType, useDashboard } from "../contexts/DashboardContext";
 import { NodeType } from "../contexts/NodesContext";
 import { hostsSchema } from "./hostsDialog/schema";
 import { AccordionInboundContent } from "./hostsDialog/AccordionInboundContent";
@@ -17,23 +17,14 @@ import { AccordionInboundContent } from "./hostsDialog/AccordionInboundContent";
 type AccordionInboundType = {
   hostKey: string;
   isOpen: boolean;
+  inbound?: InboundType;
   bots: Bot[];
   nodes: NodeType[];
   toggleAccordion: () => void;
 };
 
 export const AccordionInbound: FC<AccordionInboundType> = React.memo(
-  ({ hostKey, isOpen, bots, nodes, toggleAccordion }) => {
-    const { inbounds } = useDashboard();
-
-    const inbound = useMemo(
-      () =>
-        Array.from(inbounds.values())
-          .flat()
-          .find((i) => i.tag === hostKey),
-      [inbounds, hostKey]
-    );
-
+  ({ hostKey, isOpen, inbound, bots, nodes, toggleAccordion }) => {
     const form = useFormContext<z.infer<typeof hostsSchema>>();
     const { errors } = form.formState;
     const accordionErrors = errors[hostKey];
@@ -42,10 +33,11 @@ export const AccordionInbound: FC<AccordionInboundType> = React.memo(
       if (accordionErrors && !isOpen) {
         toggleAccordion();
       }
-    }, [accordionErrors, isOpen, toggleAccordion]);
+    }, [accordionErrors]);
 
     return (
       <AccordionItem
+        mb={1}
         border="1px solid"
         _dark={{ borderColor: "gray.600" }}
         _light={{ borderColor: "gray.200" }}
@@ -67,7 +59,7 @@ export const AccordionInbound: FC<AccordionInboundType> = React.memo(
           </Text>
           <AccordionIcon />
         </AccordionButton>
-        {isOpen && (
+        {isOpen ? (
           <AccordionInboundContent
             hostKey={hostKey}
             bots={bots}
@@ -75,7 +67,7 @@ export const AccordionInbound: FC<AccordionInboundType> = React.memo(
             inbound={inbound}
             accordionErrors={accordionErrors}
           />
-        )}
+        ) : null}
       </AccordionItem>
     );
   }

--- a/app/dashboard/src/components/AccordionInbound.tsx
+++ b/app/dashboard/src/components/AccordionInbound.tsx
@@ -1,0 +1,184 @@
+import {
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Button,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import React, { FC, useCallback, useEffect, useMemo } from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import "slick-carousel/slick/slick.css";
+import { Bot } from "types/Bot";
+import { z } from "zod";
+import { useDashboard } from "../contexts/DashboardContext";
+import { NodeType } from "../contexts/NodesContext";
+import { hostsSchema } from "./hostsDialog/schema";
+import { HostRow } from "./hostsDialog/HostRow";
+import {
+  proxyALPN,
+  proxyFingerprint,
+  proxyHostSecurity,
+} from "constants/Proxies";
+
+type AccordionInboundType = {
+  hostKey: string;
+  isOpen: boolean;
+  bots: Bot[];
+  nodes: NodeType[];
+  toggleAccordion: () => void;
+};
+
+const EMPTY_HOST = {
+  host: "",
+  sni: "",
+  port: null,
+  path: null,
+  address: "",
+  remark: "",
+  mux_enable: false,
+  allowinsecure: false,
+  is_disabled: false,
+  fragment_setting: "",
+  noise_setting: "",
+  random_user_agent: false,
+  security: "inbound_default",
+  alpn: "",
+  fingerprint: "",
+  use_sni_as_host: false,
+  bot_usernames: [],
+  node_ids: [],
+};
+
+export const AccordionInbound: FC<AccordionInboundType> = React.memo(
+  ({ hostKey, isOpen, bots, nodes, toggleAccordion }) => {
+    const { inbounds } = useDashboard();
+
+    const inbound = Array.from(inbounds.values())
+      .flat()
+      .find((i) => i.tag === hostKey);
+
+    const form = useFormContext<z.infer<typeof hostsSchema>>();
+    const {
+      fields: hosts,
+      append: addHost,
+      remove: removeHost,
+      insert: insertHost,
+      move: moveHost,
+    } = useFieldArray({
+      control: form.control,
+      name: hostKey,
+    });
+
+    const { errors } = form.formState;
+    const { t } = useTranslation();
+    const accordionErrors = errors[hostKey];
+
+    const handleAddHost = useCallback(() => {
+      addHost(EMPTY_HOST);
+    }, [addHost]);
+
+    const duplicateHost = useCallback(
+      (index: number) => {
+        const value = form.getValues(`${hostKey}.${index}`);
+        if (!value) return;
+        insertHost(index + 1, structuredClone(value));
+      },
+      [form, insertHost, hostKey]
+    );
+
+    useEffect(() => {
+      if (accordionErrors && !isOpen) {
+        toggleAccordion();
+      }
+    }, [accordionErrors, isOpen, toggleAccordion]);
+
+    const moveHostPosition = useCallback(
+      (index: number, direction: "up" | "down") => {
+        if (direction === "up" && index > 0) {
+          moveHost(index, index - 1);
+        } else if (direction === "down" && index < hosts.length - 1) {
+          moveHost(index, index + 1);
+        }
+      },
+      [moveHost, hosts.length]
+    );
+
+    const removeHostCallback = useCallback(
+      (index: number) => {
+        removeHost(index);
+      },
+      [removeHost]
+    );
+
+    return (
+      <AccordionItem
+        border="1px solid"
+        _dark={{ borderColor: "gray.600" }}
+        _light={{ borderColor: "gray.200" }}
+        borderRadius="4px"
+        p={1}
+        w="full"
+      >
+        <AccordionButton px={2} borderRadius="3px" onClick={toggleAccordion}>
+          <Text
+            as="span"
+            fontWeight="medium"
+            fontSize="sm"
+            flex="1"
+            textAlign="left"
+            color="gray.700"
+            _dark={{ color: "gray.300" }}
+          >
+            {hostKey}
+          </Text>
+          <AccordionIcon />
+        </AccordionButton>
+        {isOpen && (
+          <AccordionPanel px={2} pb={2}>
+            <VStack gap={3}>
+              {hosts.map((host, index) => (
+                <HostRow
+                  key={host.id}
+                  hostId={host.id}
+                  hostKey={hostKey}
+                  index={index}
+                  hostsLength={hosts.length}
+                  duplicateHost={duplicateHost}
+                  moveHostPosition={moveHostPosition}
+                  removeHost={removeHostCallback}
+                  bots={bots}
+                  nodes={nodes}
+                  inbound={inbound}
+                  inboundPort={inbound?.port}
+                  accordionErrors={accordionErrors}
+                  register={form.register}
+                  control={form.control}
+                  proxyHostSecurity={proxyHostSecurity}
+                  proxyALPN={proxyALPN}
+                  proxyFingerprint={proxyFingerprint}
+                  t={t}
+                />
+              ))}
+
+              <Button
+                variant="outline"
+                type="button"
+                w="full"
+                size="sm"
+                fontWeight="normal"
+                onClick={handleAddHost}
+              >
+                {t("hostsDialog.addHost")}
+              </Button>
+            </VStack>
+          </AccordionPanel>
+        )}
+      </AccordionItem>
+    );
+  }
+);
+
+AccordionInbound.displayName = "AccordionInbound";

--- a/app/dashboard/src/components/HostsDialog.tsx
+++ b/app/dashboard/src/components/HostsDialog.tsx
@@ -1334,7 +1334,7 @@ const AccordionInbound: FC<AccordionInboundType> = ({
                                 render={({ field }) => {
                                   const selectedIds: number[] = field.value || [];
                                   return (
-                                    <Popover placement="bottom-start">
+                                    <Popover isLazy placement="bottom-start">
                                       <PopoverTrigger>
                                         <Button
                                           variant="outline"

--- a/app/dashboard/src/components/HostsDialog.tsx
+++ b/app/dashboard/src/components/HostsDialog.tsx
@@ -9,7 +9,6 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
-  VStack,
   useToast,
 } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -35,9 +34,18 @@ export const HostsDialog: FC = () => {
   const { isLoading, hosts, fetchHosts, isPostLoading, setHosts } = useHosts();
   const toast = useToast();
   const { t } = useTranslation();
-  const [openAccordions, setOpenAccordions] = useState<number[]>([]);
+  const [openAccordions, setOpenAccordions] = useState<string[]>([]);
   const [bots, setBots] = useState<Bot[]>([]);
   const [nodes, setNodes] = useState<NodeType[]>([]);
+  const inboundMap = useMemo(() => {
+    const map = new Map();
+    const list =
+      inbounds instanceof Map ? Array.from(inbounds.values()).flat() : [];
+    for (const i of list) {
+      map.set(i.tag, i);
+    }
+    return map;
+  }, [inbounds]);
 
   const hostKeys = useMemo(() => {
     return hosts ? Object.keys(hosts) : [];
@@ -65,6 +73,7 @@ export const HostsDialog: FC = () => {
 
   const form = useForm<z.infer<typeof hostsSchema>>({
     resolver: zodResolver(hostsSchema),
+    shouldUnregister: false,
   });
 
   useEffect(() => {
@@ -118,29 +127,17 @@ export const HostsDialog: FC = () => {
     [setHosts, toast, t, refetchUsers, onClose]
   );
 
-  const toggleAccordion = useCallback((index: number) => {
+  const toggleAccordion = useCallback((hostKey: string) => {
     setOpenAccordions((prev) => {
-      if (prev.includes(index)) {
-        return prev.filter((i) => i !== index);
+      if (prev.includes(hostKey)) {
+        return prev.filter((k) => k !== hostKey);
       }
-      return [...prev, index];
+      return [...prev, hostKey];
     });
   }, []);
 
   const isAccordionOpen = useCallback(
-    (index: number) => {
-      return openAccordions.includes(index);
-    },
-    [openAccordions]
-  );
-
-  const accordionProps = useMemo(
-    () => ({
-      w: "full",
-      allowToggle: true,
-      allowMultiple: true,
-      index: openAccordions,
-    }),
+    (hostKey: string) => openAccordions.includes(hostKey),
     [openAccordions]
   );
 
@@ -154,31 +151,23 @@ export const HostsDialog: FC = () => {
     }
 
     return (
-      <Accordion {...accordionProps}>
-        <VStack w="full">
-          {hostKeys.map((hostKey, index) => (
+      <Accordion w="full" allowMultiple>
+        {hostKeys.map((hostKey) => {
+          return (
             <AccordionInbound
               key={hostKey}
               hostKey={hostKey}
-              isOpen={isAccordionOpen(index)}
-              toggleAccordion={() => toggleAccordion(index)}
+              isOpen={isAccordionOpen(hostKey)}
+              toggleAccordion={() => toggleAccordion(hostKey)}
               bots={bots}
               nodes={nodes}
+              inbound={inboundMap.get(hostKey)}
             />
-          ))}
-        </VStack>
+          );
+        })}
       </Accordion>
     );
-  }, [
-    isLoading,
-    hosts,
-    hostKeys,
-    accordionProps,
-    isAccordionOpen,
-    bots,
-    nodes,
-    t,
-  ]);
+  }, [isLoading, hosts, hostKeys, isAccordionOpen, bots, nodes, t]);
 
   return (
     <Modal isOpen={isEditingHosts} onClose={onClose}>

--- a/app/dashboard/src/components/HostsDialog.tsx
+++ b/app/dashboard/src/components/HostsDialog.tsx
@@ -43,9 +43,6 @@ export const HostsDialog: FC = () => {
     return hosts ? Object.keys(hosts) : [];
   }, [hosts]);
 
-  const memoizedBots = useMemo(() => bots, [bots]);
-  const memoizedNodes = useMemo(() => nodes, [nodes]);
-
   useEffect(() => {
     if (!isEditingHosts) return;
 
@@ -130,13 +127,6 @@ export const HostsDialog: FC = () => {
     });
   }, []);
 
-  const handleAccordionToggle = useCallback(
-    (index: number) => {
-      return () => toggleAccordion(index);
-    },
-    [toggleAccordion]
-  );
-
   const isAccordionOpen = useCallback(
     (index: number) => {
       return openAccordions.includes(index);
@@ -172,8 +162,8 @@ export const HostsDialog: FC = () => {
               hostKey={hostKey}
               isOpen={isAccordionOpen(index)}
               toggleAccordion={() => toggleAccordion(index)}
-              bots={memoizedBots}
-              nodes={memoizedNodes}
+              bots={bots}
+              nodes={nodes}
             />
           ))}
         </VStack>
@@ -185,7 +175,6 @@ export const HostsDialog: FC = () => {
     hostKeys,
     accordionProps,
     isAccordionOpen,
-    handleAccordionToggle,
     bots,
     nodes,
     t,

--- a/app/dashboard/src/components/HostsDialog.tsx
+++ b/app/dashboard/src/components/HostsDialog.tsx
@@ -1,66 +1,22 @@
 import {
   Accordion,
-  AccordionButton,
-  AccordionIcon,
-  AccordionItem,
-  AccordionPanel,
-  Badge,
-  Box,
   Button,
-  Select as ChakraSelect,
-  Checkbox,
-  Container,
-  FormControl,
-  FormErrorMessage,
-  FormLabel,
   HStack,
-  IconButton,
-  InputGroup,
-  InputRightElement,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverCloseButton,
-  PopoverContent,
-  PopoverTrigger,
-  Portal,
-  Switch,
   Text,
-  Tooltip,
   VStack,
-  chakra,
   useToast,
 } from "@chakra-ui/react";
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  DocumentDuplicateIcon,
-  InformationCircleIcon,
-  LinkIcon,
-} from "@heroicons/react/24/outline";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  proxyALPN,
-  proxyFingerprint,
-  proxyHostSecurity,
-} from "constants/Proxies";
 import { useHosts } from "contexts/HostsContext";
-import { motion } from "framer-motion";
-import { ChangeEvent, FC, useEffect, useState } from "react";
-import {
-  Controller,
-  FormProvider,
-  useFieldArray,
-  useForm,
-  useFormContext,
-} from "react-hook-form";
-import { Trans, useTranslation } from "react-i18next";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { fetch } from "service/http";
 import "slick-carousel/slick/slick-theme.css";
 import "slick-carousel/slick/slick.css";
@@ -68,1374 +24,10 @@ import { Bot } from "types/Bot";
 import { z } from "zod";
 import { useDashboard } from "../contexts/DashboardContext";
 import { NodeType } from "../contexts/NodesContext";
-import { DeleteIcon } from "./DeleteUserModal";
 import { Icon } from "./Icon";
-import { Input as CustomInput } from "./Input";
-
-export const DuplicateIcon = chakra(DocumentDuplicateIcon, {
-  baseStyle: {
-    w: 5,
-    h: 5,
-  },
-});
-
-export const UpIcon = chakra(ArrowUpIcon, {
-  baseStyle: {
-    w: 5,
-    h: 5,
-  },
-});
-
-export const DownIcon = chakra(ArrowDownIcon, {
-  baseStyle: {
-    w: 5,
-    h: 5,
-  },
-});
-
-const Select = chakra(ChakraSelect, {
-  baseStyle: {
-    bg: "white",
-    _dark: {
-      bg: "gray.700",
-    },
-  },
-});
-
-const Input = chakra(CustomInput, {
-  baseStyle: {
-    bg: "white",
-    _dark: {
-      bg: "gray.700",
-    },
-  },
-});
-
-const ModalIcon = chakra(LinkIcon, {
-  baseStyle: {
-    w: 5,
-    h: 5,
-  },
-});
-
-const InfoIcon = chakra(InformationCircleIcon, {
-  baseStyle: {
-    w: 4,
-    h: 4,
-    color: "gray.400",
-    cursor: "pointer",
-  },
-});
-
-const hostsSchema = z.record(
-  z.string().min(1),
-  z.array(
-    z.object({
-      remark: z.string().min(1, "Remark is required"),
-      address: z.string(),
-      port: z
-        .string()
-        .or(z.number())
-        .nullable()
-        .transform((value) => {
-          if (typeof value === "number") return value;
-          if (value !== null && !isNaN(parseInt(value)))
-            return Number(parseInt(value));
-          return null;
-        }),
-      path: z.string().nullable(),
-      sni: z.string().nullable(),
-      host: z.string().nullable(),
-      mux_enable: z.boolean().default(false),
-      allowinsecure: z.boolean().nullable().default(false),
-      is_disabled: z.boolean().default(true),
-      fragment_setting: z.string().nullable(),
-      noise_setting: z.string().nullable(),
-      random_user_agent: z.boolean().default(false),
-      security: z.string(),
-      alpn: z.string(),
-      fingerprint: z.string(),
-      use_sni_as_host: z.boolean().default(false),
-      bot_usernames: z.array(z.string()).default([]),
-      node_ids: z.array(z.number()).default([]),
-    }).superRefine((data, ctx) => {
-      if (!data.address && (!data.node_ids || data.node_ids.length === 0)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["address"],
-          message: "Address or linked nodes required",
-        });
-      }
-    })
-  )
-);
-
-const Error = chakra(FormErrorMessage, {
-  baseStyle: {
-    color: "red.400",
-    display: "block",
-    textAlign: "left",
-    w: "100%",
-  },
-});
-
-type AccordionInboundType = {
-  hostKey: string;
-  isOpen: boolean;
-  bots: Bot[];
-  nodes: NodeType[];
-  toggleAccordion: () => void;
-};
-
-const AccordionInbound: FC<AccordionInboundType> = ({
-  hostKey,
-  isOpen,
-  bots,
-  nodes,
-  toggleAccordion,
-}) => {
-  const { inbounds } = useDashboard();
-  const inbound = [...inbounds.values()]
-    .flat()
-    .filter((inbound) => inbound.tag === hostKey)[0];
-
-  const form = useFormContext<z.infer<typeof hostsSchema>>();
-  const {
-    fields: hosts,
-    append: addHost,
-    remove: removeHost,
-    insert: insertHost,
-    move: moveHost,
-  } = useFieldArray({
-    control: form.control,
-    name: hostKey,
-  });
-  const { errors } = form.formState;
-  const { t } = useTranslation();
-  const accordionErrors = errors[hostKey];
-  const handleAddHost = () => {
-    addHost({
-      host: "",
-      sni: "",
-      port: null,
-      path: null,
-      address: "",
-      remark: "",
-      mux_enable: false,
-      allowinsecure: false,
-      is_disabled: false,
-      fragment_setting: "",
-      noise_setting: "",
-      random_user_agent: false,
-      security: "inbound_default",
-      alpn: "",
-      fingerprint: "",
-      use_sni_as_host: false,
-      bot_usernames: [],
-      node_ids: [],
-    });
-  };
-  const duplicateHost = (index: number) => {
-    if (index < 0 || index >= hosts.length) return;
-    const hostToDuplicate = hosts[index];
-    insertHost(index + 1, hostToDuplicate);
-  };
-  useEffect(() => {
-    if (accordionErrors && !isOpen) {
-      toggleAccordion();
-    }
-  }, [accordionErrors]);
-
-  const moveHostPosition = (index: number, direction: "up" | "down") => {
-    if (direction === "up" && index > 0) {
-      moveHost(index, index - 1);
-    } else if (direction === "down" && index < hosts.length - 1) {
-      moveHost(index, index + 1);
-    }
-  };
-
-  return (
-    <AccordionItem
-      border="1px solid"
-      _dark={{ borderColor: "gray.600" }}
-      _light={{ borderColor: "gray.200" }}
-      borderRadius="4px"
-      p={1}
-      w="full"
-    >
-      <AccordionButton px={2} borderRadius="3px" onClick={toggleAccordion}>
-        <Text
-          as="span"
-          fontWeight="medium"
-          fontSize="sm"
-          flex="1"
-          textAlign="left"
-          color="gray.700"
-          _dark={{ color: "gray.300" }}
-        >
-          {hostKey}
-        </Text>
-        <AccordionIcon />
-      </AccordionButton>
-      <AccordionPanel px={2} pb={2}>
-        <VStack gap={3}>
-          {hosts.map((host, index) => {
-            return (
-              <motion.div
-                key={host.id}
-                layout
-                initial={false}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{
-                  layout: { type: "spring", stiffness: 500, damping: 30 },
-                  opacity: { duration: 0.1 },
-                }}
-                id={host.id}
-                whileDrag={{ scale: 1.05, zIndex: 10 }}
-                style={{
-                  width: "100%",
-                }}
-              >
-                <VStack
-                  id={host.id}
-                  key={host.id}
-                  border="1px solid"
-                  _dark={{ borderColor: "gray.600", bg: "#273142" }}
-                  _light={{ borderColor: "gray.200", bg: "#fcfbfb" }}
-                  p={2}
-                  w="full"
-                  borderRadius="4px"
-                >
-                  <HStack w="100%" alignItems="flex-start">
-                    <FormControl
-                      position="relative"
-                      zIndex={10}
-                      isInvalid={
-                        !!(accordionErrors && accordionErrors[index]?.remark)
-                      }
-                    >
-                      <InputGroup>
-                        <Input
-                          {...form.register(hostKey + "." + index + ".remark")}
-                          size="sm"
-                          borderRadius="4px"
-                          placeholder="Remark"
-                        />
-                        <InputRightElement>
-                          <Popover isLazy placement="right">
-                            <PopoverTrigger>
-                              <Box mt="-8px">
-                                <InfoIcon />
-                              </Box>
-                            </PopoverTrigger>
-                            <Portal>
-                              <PopoverContent>
-                                <PopoverArrow />
-                                <PopoverCloseButton />
-                                <PopoverBody>
-                                  <Box fontSize="xs">
-                                    <Text pr="20px">
-                                      {t("hostsDialog.desc")}
-                                    </Text>
-                                    <Text>
-                                      <Badge>
-                                        {"{"}SERVER_IP{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.currentServer")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}SERVER_IPV6{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.currentServerv6")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}USERNAME{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.username")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}DATA_USAGE{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.dataUsage")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}DATA_LEFT{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.remainingData")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}DATA_LIMIT{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.dataLimit")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}DAYS_LEFT{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.remainingDays")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}EXPIRE_DATE{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.expireDate")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}JALALI_EXPIRE_DATE{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.jalaliExpireDate")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}TIME_LEFT{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.remainingTime")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}STATUS_TEXT{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.statusText")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}STATUS_EMOJI{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.statusEmoji")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}PROTOCOL{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.proxyProtocol")}
-                                    </Text>
-                                    <Text mt={1}>
-                                      <Badge>
-                                        {"{"}TRANSPORT{"}"}
-                                      </Badge>{" "}
-                                      {t("hostsDialog.proxyMethod")}
-                                    </Text>
-                                  </Box>
-                                </PopoverBody>
-                              </PopoverContent>
-                            </Portal>
-                          </Popover>
-                        </InputRightElement>
-                      </InputGroup>
-                      {accordionErrors && accordionErrors[index]?.remark && (
-                        <Error>{accordionErrors[index]?.remark?.message}</Error>
-                      )}
-                    </FormControl>
-                  </HStack>
-                  <FormControl
-                    isInvalid={
-                      !!(accordionErrors && accordionErrors[index]?.address)
-                    }
-                  >
-                    <InputGroup>
-                      <Input
-                        size="sm"
-                        borderRadius="4px"
-                        placeholder="Address (e.g. example.com)"
-                        {...form.register(hostKey + "." + index + ".address")}
-                      />
-                      <InputRightElement>
-                        <Popover isLazy placement="right">
-                          <PopoverTrigger>
-                            <Box mt="-8px">
-                              <InfoIcon />
-                            </Box>
-                          </PopoverTrigger>
-                          <Portal>
-                            <PopoverContent>
-                              <PopoverArrow />
-                              <PopoverCloseButton />
-                              <PopoverBody>
-                                <Box fontSize="xs">
-                                  <Text pr="20px">{t("hostsDialog.desc")}</Text>
-                                  <Text>
-                                    <Badge>
-                                      {"{"}SERVER_IP{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.currentServer")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}SERVER_IPV6{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.currentServerv6")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}USERNAME{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.username")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}DATA_USAGE{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.dataUsage")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}DATA_LEFT{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.remainingData")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}DATA_LIMIT{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.dataLimit")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}DAYS_LEFT{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.remainingDays")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}EXPIRE_DATE{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.expireDate")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}JALALI_EXPIRE_DATE{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.jalaliExpireDate")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}TIME_LEFT{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.remainingTime")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}STATUS_TEXT{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.statusText")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}STATUS_EMOJI{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.statusEmoji")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}PROTOCOL{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.proxyProtocol")}
-                                  </Text>
-                                  <Text mt={1}>
-                                    <Badge>
-                                      {"{"}TRANSPORT{"}"}
-                                    </Badge>{" "}
-                                    {t("hostsDialog.proxyMethod")}
-                                  </Text>
-                                </Box>
-                              </PopoverBody>
-                            </PopoverContent>
-                          </Portal>
-                        </Popover>
-                      </InputRightElement>
-                    </InputGroup>
-                    {accordionErrors && accordionErrors[index]?.address && (
-                      <Error>{accordionErrors[index]?.address?.message}</Error>
-                    )}
-                  </FormControl>
-
-                  <Accordion w="full" allowToggle>
-                    <AccordionItem border="0">
-                      <div style={{ display: "flex", alignItems: "center" }}>
-                        <AccordionButton
-                          display="flex"
-                          px={0}
-                          py={1}
-                          borderRadius={3}
-                          _hover={{ bg: "transparent" }}
-                        >
-                          <Text
-                            flex="3"
-                            align="start"
-                            fontSize="xs"
-                            color="gray.600"
-                            _dark={{ color: "gray.500" }}
-                            pl={1}
-                          >
-                            {t("hostsDialog.advancedOptions")}
-                            <AccordionIcon fontSize="sm" ml={1} />
-                          </Text>
-
-                          <Container flex="1" px="0" display={"contents"}>
-                            <Controller
-                              control={form.control}
-                              name={`${hostKey}.${index}.is_disabled`}
-                              render={({ field }) => {
-                                return (
-                                  <Switch
-                                    mx="1.5"
-                                    colorScheme="primary"
-                                    {...field}
-                                    value={undefined}
-                                    isChecked={!field.value}
-                                    onChange={(e) => {
-                                      console.log(e.target.checked);
-                                      field.onChange(!e.target.checked);
-                                    }}
-                                  />
-                                );
-                              }}
-                            />
-                            <Tooltip label="Delete" placement="top">
-                              <IconButton
-                                aria-label="Delete"
-                                size="sm"
-                                colorScheme="red"
-                                variant="ghost"
-                                onClick={removeHost.bind(null, index)}
-                              >
-                                <DeleteIcon />
-                              </IconButton>
-                            </Tooltip>
-                          </Container>
-                        </AccordionButton>
-                        <Tooltip label="Duplicate" placement="top">
-                          <IconButton
-                            aria-label="Duplicate"
-                            size="sm"
-                            colorScheme="white"
-                            variant="ghost"
-                            onClick={() => duplicateHost(index)}
-                          >
-                            <DuplicateIcon />
-                          </IconButton>
-                        </Tooltip>
-                        {index < hosts.length - 1 && (
-                          <Tooltip label="Move Down" placement="top">
-                            <IconButton
-                              aria-label="DownIcon"
-                              size="sm"
-                              colorScheme="white"
-                              variant="ghost"
-                              onClick={() => moveHostPosition(index, "down")}
-                            >
-                              <DownIcon />
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        {index > 0 && (
-                          <Tooltip label="Move Up" placement="top">
-                            <IconButton
-                              aria-label="UpIcon"
-                              size="sm"
-                              colorScheme="white"
-                              variant="ghost"
-                              onClick={() => moveHostPosition(index, "up")}
-                            >
-                              <UpIcon />
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                      </div>
-                      <AccordionPanel w="full" p={1}>
-                        <VStack key={index} w="full" borderRadius="4px">
-                          <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors && accordionErrors[index]?.port
-                              )
-                            }
-                          >
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              justifyContent="space-between"
-                              gap={1}
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.port")}</span>
-                              <Popover isLazy placement="right">
-                                <PopoverTrigger>
-                                  <InfoIcon />
-                                </PopoverTrigger>
-                                <Portal>
-                                  <PopoverContent p={2}>
-                                    <PopoverArrow />
-                                    <PopoverCloseButton />
-                                    <Text fontSize="xs" pr={5}>
-                                      {t("hostsDialog.port.info")}
-                                    </Text>
-                                  </PopoverContent>
-                                </Portal>
-                              </Popover>
-                            </FormLabel>
-                            <Input
-                              size="sm"
-                              borderRadius="4px"
-                              placeholder={String(inbound.port || "8080")}
-                              type="number"
-                              {...form.register(
-                                hostKey + "." + index + ".port"
-                              )}
-                            />
-                          </FormControl>
-                          <FormControl
-                            isInvalid={
-                              !!(accordionErrors && accordionErrors[index]?.sni)
-                            }
-                          >
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              gap={1}
-                              justifyContent="space-between"
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.sni")}</span>
-
-                              <Popover isLazy placement="right">
-                                <PopoverTrigger>
-                                  <InfoIcon />
-                                </PopoverTrigger>
-                                <Portal>
-                                  <PopoverContent p={2}>
-                                    <PopoverArrow />
-                                    <PopoverCloseButton />
-                                    <Text fontSize="xs" pr={5}>
-                                      {t("hostsDialog.sni.info")}
-                                    </Text>
-                                    <Text fontSize="xs" mt="2">
-                                      <Trans
-                                        i18nKey="hostsDialog.host.wildcard"
-                                        components={{
-                                          badge: <Badge />,
-                                        }}
-                                      />
-                                    </Text>
-                                    <Text fontSize="xs">
-                                      <Trans
-                                        i18nKey="hostsDialog.host.multiHost"
-                                        components={{
-                                          badge: <Badge />,
-                                        }}
-                                      />
-                                    </Text>
-                                  </PopoverContent>
-                                </Portal>
-                              </Popover>
-                            </FormLabel>
-                            <Input
-                              size="sm"
-                              borderRadius="4px"
-                              placeholder="SNI (e.g. example.com)"
-                              {...form.register(hostKey + "." + index + ".sni")}
-                            />
-                            {accordionErrors && accordionErrors[index]?.sni && (
-                              <Error>
-                                {accordionErrors[index]?.sni?.message}
-                              </Error>
-                            )}
-                          </FormControl>
-                          <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors && accordionErrors[index]?.host
-                              )
-                            }
-                          >
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              gap={1}
-                              justifyContent="space-between"
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.host")}</span>
-
-                              <Popover isLazy placement="right">
-                                <PopoverTrigger>
-                                  <InfoIcon />
-                                </PopoverTrigger>
-                                <Portal>
-                                  <PopoverContent p={2}>
-                                    <PopoverArrow />
-                                    <PopoverCloseButton />
-                                    <Text fontSize="xs" pr={5}>
-                                      {t("hostsDialog.host.info")}
-                                    </Text>
-                                    <Text fontSize="xs" mt="2">
-                                      <Trans
-                                        i18nKey="hostsDialog.host.wildcard"
-                                        components={{
-                                          badge: <Badge />,
-                                        }}
-                                      />
-                                    </Text>
-                                    <Text fontSize="xs">
-                                      <Trans
-                                        i18nKey="hostsDialog.host.multiHost"
-                                        components={{
-                                          badge: <Badge />,
-                                        }}
-                                      />
-                                    </Text>
-                                  </PopoverContent>
-                                </Portal>
-                              </Popover>
-                            </FormLabel>
-                            <Input
-                              size="sm"
-                              borderRadius="4px"
-                              placeholder="Host (e.g. example.com)"
-                              {...form.register(
-                                hostKey + "." + index + ".host"
-                              )}
-                            />
-                            {accordionErrors &&
-                              accordionErrors[index]?.host && (
-                                <Error>
-                                  {accordionErrors[index]?.host?.message}
-                                </Error>
-                              )}
-                          </FormControl>
-
-                          <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors && accordionErrors[index]?.path
-                              )
-                            }
-                          >
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              gap={1}
-                              justifyContent="space-between"
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.path")}</span>
-
-                              <Popover isLazy placement="right">
-                                <PopoverTrigger>
-                                  <InfoIcon />
-                                </PopoverTrigger>
-                                <Portal>
-                                  <PopoverContent p={2}>
-                                    <PopoverArrow />
-                                    <PopoverCloseButton />
-                                    <Text fontSize="xs" pr={5}>
-                                      {t("hostsDialog.path.info")}
-                                    </Text>
-                                  </PopoverContent>
-                                </Portal>
-                              </Popover>
-                            </FormLabel>
-                            <Input
-                              size="sm"
-                              borderRadius="4px"
-                              placeholder="path (e.g. /vless)"
-                              {...form.register(
-                                hostKey + "." + index + ".path"
-                              )}
-                            />
-                            {accordionErrors &&
-                              accordionErrors[index]?.path && (
-                                <Error>
-                                  {accordionErrors[index]?.path?.message}
-                                </Error>
-                              )}
-                          </FormControl>
-
-                          <FormControl height="66px">
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              gap={1}
-                              justifyContent="space-between"
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.security")}</span>
-
-                              <Popover isLazy placement="right">
-                                <PopoverTrigger>
-                                  <InfoIcon />
-                                </PopoverTrigger>
-                                <Portal>
-                                  <PopoverContent p={2}>
-                                    <PopoverArrow />
-                                    <PopoverCloseButton />
-                                    <Text fontSize="xs" pr={5}>
-                                      {t("hostsDialog.security.info")}
-                                    </Text>
-                                  </PopoverContent>
-                                </Portal>
-                              </Popover>
-                            </FormLabel>
-                            <Select
-                              size="sm"
-                              {...form.register(
-                                hostKey + "." + index + ".security"
-                              )}
-                            >
-                              {proxyHostSecurity.map((s) => {
-                                return (
-                                  <option key={s.value} value={s.value}>
-                                    {s.title}
-                                  </option>
-                                );
-                              })}
-                            </Select>
-                          </FormControl>
-
-                          <FormControl height="66px">
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              gap={1}
-                              justifyContent="space-between"
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.alpn")}</span>
-                            </FormLabel>
-                            <Select
-                              size="sm"
-                              {...form.register(
-                                hostKey + "." + index + ".alpn"
-                              )}
-                            >
-                              {proxyALPN.map((s) => {
-                                return (
-                                  <option key={s.value} value={s.value}>
-                                    {s.title}
-                                  </option>
-                                );
-                              })}
-                            </Select>
-                          </FormControl>
-
-                          <FormControl height="66px">
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              gap={1}
-                              justifyContent="space-between"
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.fingerprint")}</span>
-                            </FormLabel>
-                            <Select
-                              size="sm"
-                              {...form.register(
-                                hostKey + "." + index + ".fingerprint"
-                              )}
-                            >
-                              {proxyFingerprint.map((s) => {
-                                return (
-                                  <option key={s.value} value={s.value}>
-                                    {s.title}
-                                  </option>
-                                );
-                              })}
-                            </Select>
-                          </FormControl>
-
-                          <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors &&
-                                accordionErrors[index]?.fragment_setting
-                              )
-                            }
-                          >
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              gap={1}
-                              justifyContent="space-between"
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.fragment")}</span>
-
-                              <Popover isLazy placement="right">
-                                <PopoverTrigger>
-                                  <InfoIcon />
-                                </PopoverTrigger>
-                                <Portal>
-                                  <PopoverContent p={2}>
-                                    <PopoverArrow />
-                                    <PopoverCloseButton />
-                                    <Text fontSize="xs" pr={5}>
-                                      {t("hostsDialog.fragment.info")}
-                                    </Text>
-                                    <Text fontSize="xs" pr={5} pt={2} pb={1}>
-                                      {t("hostsDialog.fragment.info.examples")}
-                                    </Text>
-                                    <Text fontSize="xs" pr={5}>
-                                      100-200,10-20,tlshello
-                                    </Text>
-                                    <Text fontSize="xs" pr={5}>
-                                      100-200,10-20,1-3
-                                    </Text>
-                                    <Text fontSize="xs" pr={5} pt="3">
-                                      {t("hostsDialog.fragment.info.attention")}
-                                    </Text>
-                                  </PopoverContent>
-                                </Portal>
-                              </Popover>
-                            </FormLabel>
-                            <Input
-                              size="sm"
-                              borderRadius="4px"
-                              placeholder="Fragment settings by pattern"
-                              {...form.register(
-                                hostKey + "." + index + ".fragment_setting"
-                              )}
-                            />
-                            {accordionErrors &&
-                              accordionErrors[index]?.fragment_setting && (
-                                <Error>
-                                  {
-                                    accordionErrors[index]?.fragment_setting
-                                      ?.message
-                                  }
-                                </Error>
-                              )}
-                          </FormControl>
-
-                          <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors &&
-                                accordionErrors[index]?.noise_setting
-                              )
-                            }
-                          >
-                            <FormLabel
-                              display="flex"
-                              pb={1}
-                              alignItems="center"
-                              gap={1}
-                              justifyContent="space-between"
-                              m="0"
-                            >
-                              <span>{t("hostsDialog.noise")}</span>
-
-                              <Popover isLazy placement="right">
-                                <PopoverTrigger>
-                                  <InfoIcon />
-                                </PopoverTrigger>
-                                <Portal>
-                                  <PopoverContent p={2}>
-                                    <PopoverArrow />
-                                    <PopoverCloseButton />
-                                    <Text fontSize="xs" pr={5}>
-                                      {t("hostsDialog.noise.info")}
-                                    </Text>
-                                    <Text fontSize="xs" pr={5} pt={2} pb={1}>
-                                      {t("hostsDialog.noise.info.examples")}
-                                    </Text>
-                                    <Text fontSize="xs" pr={5}>
-                                      rand:10-20,10-20
-                                    </Text>
-                                    <Text fontSize="xs" pr={5}>
-                                      rand:10-20,10-20&base64:7nQBAAABAAAAAAAABnQtcmluZwZtc2VkZ2UDbmV0AAABAAE=,10-25
-                                    </Text>
-                                    <Text fontSize="xs" pr={5} pt="3">
-                                      {t("hostsDialog.noise.info.attention")}
-                                    </Text>
-                                  </PopoverContent>
-                                </Portal>
-                              </Popover>
-                            </FormLabel>
-                            <Input
-                              size="sm"
-                              borderRadius="4px"
-                              placeholder="Noise settings by pattern"
-                              {...form.register(
-                                hostKey + "." + index + ".noise_setting"
-                              )}
-                            />
-                            {accordionErrors &&
-                              accordionErrors[index]?.noise_setting && (
-                                <Error>
-                                  {
-                                    accordionErrors[index]?.noise_setting
-                                      ?.message
-                                  }
-                                </Error>
-                              )}
-                          </FormControl>
-
-
-                          <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors &&
-                                accordionErrors[index]?.use_sni_as_host
-                              )
-                            }
-                          >
-                            <Checkbox
-                              {...form.register(
-                                hostKey + "." + index + ".use_sni_as_host"
-                              )}
-                            >
-                              <FormLabel>
-                                {t("hostsDialog.useSniAsHost")}
-                              </FormLabel>
-                            </Checkbox>
-                            {accordionErrors &&
-                              accordionErrors[index]?.use_sni_as_host && (
-                                <Error>
-                                  {
-                                    accordionErrors[index]?.use_sni_as_host
-                                      ?.message
-                                  }
-                                </Error>
-                              )}
-                        </FormControl>
-                         <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors &&
-                                accordionErrors[index]?.allowinsecure
-                              )
-                            }
-                          >
-                            <Checkbox
-                              {...form.register(
-                                hostKey + "." + index + ".allowinsecure"
-                              )}
-                              name={hostKey + "." + index + ".allowinsecure"}
-                            >
-                              <FormLabel>
-                                {t("hostsDialog.allowinsecure")}
-                              </FormLabel>
-                              {accordionErrors &&
-                                accordionErrors[index]?.allowinsecure && (
-                                  <Error>
-                                    {
-                                      accordionErrors[index]?.allowinsecure
-                                        ?.message
-                                    }
-                                  </Error>
-                                )}
-                            </Checkbox>
-                          </FormControl>
-                          <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors &&
-                                accordionErrors[index]?.mux_enable
-                              )
-                            }
-                          >
-                            <Checkbox
-                              {...form.register(
-                                hostKey + "." + index + ".mux_enable"
-                              )}
-                            >
-                              <FormLabel>
-                                {t("hostsDialog.muxEnable")}
-                              </FormLabel>
-                            </Checkbox>
-                            {accordionErrors &&
-                              accordionErrors[index]?.mux_enable && (
-                                <Error>
-                                  {accordionErrors[index]?.mux_enable?.message}
-                                </Error>
-                              )}
-                          </FormControl>
-                          <FormControl
-                            isInvalid={
-                              !!(
-                                accordionErrors &&
-                                accordionErrors[index]?.random_user_agent
-                              )
-                            }
-                          >
-                            <Checkbox
-                              {...form.register(
-                                hostKey + "." + index + ".random_user_agent"
-                              )}
-                            >
-                              <FormLabel>
-                                {t("hostsDialog.randomUserAgent")}
-                              </FormLabel>
-                            </Checkbox>
-                            {accordionErrors &&
-                              accordionErrors[index]?.random_user_agent && (
-                                <Error>
-                                  {
-                                    accordionErrors[index]?.random_user_agent
-                                      ?.message
-                                  }
-                                </Error>
-                              )}
-                          </FormControl>
-                          {bots.length > 0 && (
-                            <FormControl
-                              isInvalid={
-                                !!(
-                                  accordionErrors &&
-                                  accordionErrors[index]?.bot_usernames
-                                )
-                              }
-                            >
-                              <FormLabel>
-                                {t("hostsDialog.availableBots")}
-                              </FormLabel>
-                              <Text
-                                fontSize="xs"
-                                color="gray.600"
-                                _dark={{ color: "gray.400" }}
-                                mb={2}
-                              >
-                                {t("hostsDialog.availableBots.info")}
-                              </Text>
-                              <Controller
-                                control={form.control}
-                                name={`${hostKey}.${index}.bot_usernames`}
-                                render={({ field }) => {
-                                  const selectedBotUsernames: string[] =
-                                    field.value || [];
-                                  const selectedBots = bots.filter((bot: Bot) =>
-                                    selectedBotUsernames.includes(bot.username)
-                                  );
-
-                                  return (
-                                    <Popover placement="bottom-start">
-                                      <PopoverTrigger>
-                                        <Button
-                                          variant="outline"
-                                          size="sm"
-                                          w="full"
-                                          justifyContent="space-between"
-                                        >
-                                          <Text as="span" noOfLines={1}>
-                                            {selectedBots.length
-                                              ? t(
-                                                  "hostsDialog.availableBots.selected",
-                                                  { count: selectedBots.length }
-                                                )
-                                              : t("hostsDialog.availableBots.all")}
-                                          </Text>
-                                          <AccordionIcon />
-                                        </Button>
-                                      </PopoverTrigger>
-                                      <Portal>
-                                        <PopoverContent
-                                          w="280px"
-                                          maxH="320px"
-                                          overflowY="auto"
-                                          zIndex={1500}
-                                        >
-                                          <PopoverArrow />
-                                          <PopoverCloseButton />
-                                          <PopoverBody pt={8}>
-                                            <VStack align="start" spacing={2}>
-                                              {bots.map((bot: Bot) => (
-                                                <Checkbox
-                                                  key={bot.username}
-                                                  isChecked={selectedBotUsernames.includes(
-                                                    bot.username
-                                                  )}
-                                                  onChange={(
-                                                    event: ChangeEvent<HTMLInputElement>
-                                                  ) => {
-                                                    if (event.target.checked) {
-                                                      field.onChange([
-                                                        ...selectedBotUsernames,
-                                                        bot.username,
-                                                      ]);
-                                                    } else {
-                                                      field.onChange(
-                                                        selectedBotUsernames.filter(
-                                                          (username: string) =>
-                                                            username !==
-                                                            bot.username
-                                                        )
-                                                      );
-                                                    }
-                                                  }}
-                                                >
-                                                  <Text as="span" fontSize="sm">
-                                                    @{bot.username}
-                                                    {bot.title
-                                                      ? ` (${bot.title})`
-                                                      : ""}
-                                                  </Text>
-                                                </Checkbox>
-                                              ))}
-                                              {selectedBotUsernames.length > 0 && (
-                                                <Button
-                                                  variant="ghost"
-                                                  size="xs"
-                                                  onClick={() => field.onChange([])}
-                                                >
-                                                  {t(
-                                                    "hostsDialog.availableBots.clear"
-                                                  )}
-                                                </Button>
-                                              )}
-                                            </VStack>
-                                          </PopoverBody>
-                                        </PopoverContent>
-                                      </Portal>
-                                    </Popover>
-                                  );
-                                }}
-                              />
-                              {accordionErrors &&
-                                accordionErrors[index]?.bot_usernames && (
-                                  <Error>
-                                    {
-                                      accordionErrors[index]?.bot_usernames
-                                        ?.message
-                                    }
-                                  </Error>
-                                )}
-                            </FormControl>
-                          )}
-                          {nodes.filter((n) => n.id != null).length > 0 && (
-                            <FormControl>
-                              <FormLabel>{t("hostsDialog.linkedNodes")}</FormLabel>
-                              <Text
-                                fontSize="xs"
-                                color="gray.600"
-                                _dark={{ color: "gray.400" }}
-                                mb={2}
-                              >
-                                {t("hostsDialog.linkedNodes.info")}
-                              </Text>
-                              <Controller
-                                control={form.control}
-                                name={`${hostKey}.${index}.node_ids`}
-                                render={({ field }) => {
-                                  const selectedIds: number[] = field.value || [];
-                                  return (
-                                    <Popover isLazy placement="bottom-start">
-                                      <PopoverTrigger>
-                                        <Button
-                                          variant="outline"
-                                          size="sm"
-                                          w="full"
-                                          justifyContent="space-between"
-                                        >
-                                          <Text as="span" noOfLines={1}>
-                                            {selectedIds.length
-                                              ? t("hostsDialog.linkedNodes.selected", {
-                                                  count: selectedIds.length,
-                                                })
-                                              : t("hostsDialog.linkedNodes.none")}
-                                          </Text>
-                                          <AccordionIcon />
-                                        </Button>
-                                      </PopoverTrigger>
-                                      <Portal>
-                                        <PopoverContent
-                                          w="280px"
-                                          maxH="320px"
-                                          overflowY="auto"
-                                          zIndex={1500}
-                                        >
-                                          <PopoverArrow />
-                                          <PopoverCloseButton />
-                                          <PopoverBody pt={8}>
-                                            <VStack align="start" spacing={2}>
-                                              {nodes
-                                                .filter((n) => n.id != null)
-                                                .map((node: NodeType) => {
-                                                  const nodeId = node.id as number;
-                                                  return (
-                                                    <Checkbox
-                                                      key={nodeId}
-                                                      isChecked={selectedIds.includes(nodeId)}
-                                                      onChange={(
-                                                        event: ChangeEvent<HTMLInputElement>
-                                                      ) => {
-                                                        if (event.target.checked) {
-                                                          field.onChange([
-                                                            ...selectedIds,
-                                                            nodeId,
-                                                          ]);
-                                                        } else {
-                                                          field.onChange(
-                                                            selectedIds.filter(
-                                                              (id: number) => id !== nodeId
-                                                            )
-                                                          );
-                                                        }
-                                                      }}
-                                                    >
-                                                      <Text as="span" fontSize="sm">
-                                                        {node.name}
-                                                      </Text>
-                                                    </Checkbox>
-                                                  );
-                                                })}
-                                              {selectedIds.length > 0 && (
-                                                <Button
-                                                  variant="ghost"
-                                                  size="xs"
-                                                  onClick={() => field.onChange([])}
-                                                >
-                                                  {t("hostsDialog.linkedNodes.clear")}
-                                                </Button>
-                                              )}
-                                            </VStack>
-                                          </PopoverBody>
-                                        </PopoverContent>
-                                      </Portal>
-                                    </Popover>
-                                  );
-                                }}
-                              />
-                            </FormControl>
-                          )}
-                        </VStack>
-                      </AccordionPanel>
-                    </AccordionItem>
-                  </Accordion>
-                </VStack>
-              </motion.div>
-            );
-          })}
-          <Button
-            variant="outline"
-            w="full"
-            size="sm"
-            color=""
-            fontWeight={"normal"}
-            onClick={handleAddHost}
-          >
-            {t("hostsDialog.addHost")}
-          </Button>
-        </VStack>
-      </AccordionPanel>
-    </AccordionItem>
-  );
-};
+import { hostsSchema } from "./hostsDialog/schema";
+import { ModalIcon } from "./hostsDialog/constants";
+import { AccordionInbound } from "./AccordionInbound";
 
 export const HostsDialog: FC = () => {
   const { isEditingHosts, onEditingHosts, refetchUsers, inbounds } =
@@ -1443,21 +35,37 @@ export const HostsDialog: FC = () => {
   const { isLoading, hosts, fetchHosts, isPostLoading, setHosts } = useHosts();
   const toast = useToast();
   const { t } = useTranslation();
-  const [openAccordions, setOpenAccordions] = useState<any>({});
+  const [openAccordions, setOpenAccordions] = useState<number[]>([]);
   const [bots, setBots] = useState<Bot[]>([]);
   const [nodes, setNodes] = useState<NodeType[]>([]);
+
+  const hostKeys = useMemo(() => {
+    return hosts ? Object.keys(hosts) : [];
+  }, [hosts]);
+
+  const memoizedBots = useMemo(() => bots, [bots]);
+  const memoizedNodes = useMemo(() => nodes, [nodes]);
 
   useEffect(() => {
     if (!isEditingHosts) return;
 
-    fetchHosts();
-    fetch<Bot[]>("/bots")
-      .then(setBots)
-      .catch(() => setBots([]));
-    fetch<NodeType[]>("/nodes")
-      .then(setNodes)
-      .catch(() => setNodes([]));
-  }, [isEditingHosts]);
+    const loadData = async () => {
+      try {
+        await fetchHosts();
+        const [botsData, nodesData] = await Promise.all([
+          fetch<Bot[]>("/bots").catch(() => [] as Bot[]),
+          fetch<NodeType[]>("/nodes").catch(() => [] as NodeType[]),
+        ]);
+        setBots(botsData);
+        setNodes(nodesData);
+      } catch (error) {
+        console.error("Failed to load data:", error);
+      }
+    };
+
+    loadData();
+  }, [isEditingHosts, fetchHosts]);
+
   const form = useForm<z.infer<typeof hostsSchema>>({
     resolver: zodResolver(hostsSchema),
   });
@@ -1466,55 +74,122 @@ export const HostsDialog: FC = () => {
     if (hosts && isEditingHosts) {
       form.reset(hosts);
     }
-  }, [hosts]);
+  }, [hosts, isEditingHosts, form]);
 
-  const onClose = () => {
-    setOpenAccordions({});
+  const onClose = useCallback(() => {
+    setOpenAccordions([]);
     onEditingHosts(false);
-  };
-  const handleFormSubmit = (hosts: z.infer<typeof hostsSchema>) => {
-    setHosts(hosts)
-      .then(() => {
-        toast({
-          title: t("hostsDialog.savedSuccess"),
-          status: "success",
-          isClosable: true,
-          position: "top",
-          duration: 3000,
-        });
-        refetchUsers();
-      })
-      .catch((err) => {
-        if (err?.response?.status === 409 || err?.response?.status === 400) {
+  }, [onEditingHosts]);
+
+  const handleFormSubmit = useCallback(
+    (hostsData: z.infer<typeof hostsSchema>) => {
+      setHosts(hostsData)
+        .then(() => {
           toast({
-            title: err.response?._data?.detail,
-            status: "error",
+            title: t("hostsDialog.savedSuccess"),
+            status: "success",
             isClosable: true,
             position: "top",
             duration: 3000,
           });
-        }
-        if (err?.response?.status === 422) {
-          Object.keys(err.response._data.detail).forEach((key) => {
+          refetchUsers();
+          onClose();
+        })
+        .catch((err) => {
+          if (err?.response?.status === 409 || err?.response?.status === 400) {
             toast({
-              title: err.response._data.detail[key] + " (" + key + ")",
+              title: err.response?._data?.detail,
               status: "error",
               isClosable: true,
               position: "top",
               duration: 3000,
             });
-          });
-        }
-      });
-  };
+          }
+          if (err?.response?.status === 422) {
+            Object.keys(err.response._data.detail).forEach((key) => {
+              toast({
+                title: err.response._data.detail[key] + " (" + key + ")",
+                status: "error",
+                isClosable: true,
+                position: "top",
+                duration: 3000,
+              });
+            });
+          }
+        });
+    },
+    [setHosts, toast, t, refetchUsers, onClose]
+  );
 
-  const toggleAccordion = (index: number) => {
-    if (openAccordions[String(index)]) {
-      delete openAccordions[String(index)];
-    } else openAccordions[String(index)] = {};
+  const toggleAccordion = useCallback((index: number) => {
+    setOpenAccordions((prev) => {
+      if (prev.includes(index)) {
+        return prev.filter((i) => i !== index);
+      }
+      return [...prev, index];
+    });
+  }, []);
 
-    setOpenAccordions({ ...openAccordions });
-  };
+  const handleAccordionToggle = useCallback(
+    (index: number) => {
+      return () => toggleAccordion(index);
+    },
+    [toggleAccordion]
+  );
+
+  const isAccordionOpen = useCallback(
+    (index: number) => {
+      return openAccordions.includes(index);
+    },
+    [openAccordions]
+  );
+
+  const accordionProps = useMemo(
+    () => ({
+      w: "full",
+      allowToggle: true,
+      allowMultiple: true,
+      index: openAccordions,
+    }),
+    [openAccordions]
+  );
+
+  const renderContent = useMemo(() => {
+    if (isLoading) {
+      return t("hostsDialog.loading");
+    }
+
+    if (!hosts || hostKeys.length === 0) {
+      return "No inbound found. Please check your Xray config file.";
+    }
+
+    return (
+      <Accordion {...accordionProps}>
+        <VStack w="full">
+          {hostKeys.map((hostKey, index) => (
+            <AccordionInbound
+              key={hostKey}
+              hostKey={hostKey}
+              isOpen={isAccordionOpen(index)}
+              toggleAccordion={() => toggleAccordion(index)}
+              bots={memoizedBots}
+              nodes={memoizedNodes}
+            />
+          ))}
+        </VStack>
+      </Accordion>
+    );
+  }, [
+    isLoading,
+    hosts,
+    hostKeys,
+    accordionProps,
+    isAccordionOpen,
+    handleAccordionToggle,
+    bots,
+    nodes,
+    t,
+  ]);
 
   return (
     <Modal isOpen={isEditingHosts} onClose={onClose}>
@@ -1532,35 +207,7 @@ export const HostsDialog: FC = () => {
               <Text mb={3} opacity={0.8} fontSize="sm">
                 {t("hostsDialog.title")}
               </Text>
-              {isLoading && t("hostsDialog.loading")}
-              {!isLoading &&
-                hosts &&
-                (Object.keys(hosts).length > 0 ? (
-                  <Accordion
-                    w="full"
-                    allowToggle
-                    allowMultiple
-                    index={Object.keys(openAccordions).map((i) => parseInt(i))}
-                  >
-                    <VStack w="full">
-                      {Object.keys(hosts).map((hostKey, index) => {
-                        return (
-                          <AccordionInbound
-                            toggleAccordion={() => toggleAccordion(index)}
-                            isOpen={openAccordions[String(index)]}
-                            key={hostKey}
-                            hostKey={hostKey}
-                            bots={bots}
-                            nodes={nodes}
-                          />
-                        );
-                      })}
-                    </VStack>
-                  </Accordion>
-                ) : (
-                  "No inbound found. Please check your Xray config file."
-                ))}
-
+              {renderContent}
               <HStack justifyContent="flex-end" py={2}>
                 <Button
                   variant="solid"

--- a/app/dashboard/src/components/hostsDialog/AccordionInboundContent.tsx
+++ b/app/dashboard/src/components/hostsDialog/AccordionInboundContent.tsx
@@ -1,0 +1,147 @@
+import { Button, AccordionPanel, VStack } from "@chakra-ui/react";
+import { FC, useCallback, useEffect } from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+
+import { Bot } from "types/Bot";
+import {
+  proxyALPN,
+  proxyFingerprint,
+  proxyHostSecurity,
+} from "constants/Proxies";
+import { NodeType } from "contexts/NodesContext";
+import { hostsSchema } from "./schema";
+import { HostRow } from "./HostRow";
+
+const EMPTY_HOST = {
+  host: "",
+  sni: "",
+  port: null,
+  path: null,
+  address: "",
+  remark: "",
+  mux_enable: false,
+  allowinsecure: false,
+  is_disabled: false,
+  fragment_setting: "",
+  noise_setting: "",
+  random_user_agent: false,
+  security: "inbound_default",
+  alpn: "",
+  fingerprint: "",
+  use_sni_as_host: false,
+  bot_usernames: [],
+  node_ids: [],
+};
+
+type Props = {
+  hostKey: string;
+  bots: Bot[];
+  nodes: NodeType[];
+  inbound: any;
+  accordionErrors: any;
+};
+
+export const AccordionInboundContent: FC<Props> = ({
+  hostKey,
+  bots,
+  nodes,
+  inbound,
+  accordionErrors,
+}) => {
+  useEffect(() => {
+    console.log("Mounted:", hostKey);
+    return () => {
+      console.log("Unmounted:", hostKey);
+    };
+  }, []);
+
+  const { t } = useTranslation();
+  const form = useFormContext<z.infer<typeof hostsSchema>>();
+
+  console.log("Creating useFieldArray for", hostKey);
+  const {
+    fields: hosts,
+    append,
+    remove,
+    insert,
+    move,
+  } = useFieldArray({
+    control: form.control,
+    name: hostKey,
+  });
+
+  const handleAddHost = useCallback(() => {
+    append(EMPTY_HOST);
+  }, [append]);
+
+  const duplicateHost = useCallback(
+    (index: number) => {
+      const value = form.getValues(`${hostKey}.${index}`);
+      if (!value) return;
+
+      insert(index + 1, structuredClone(value));
+    },
+    [form, hostKey, insert]
+  );
+
+  const moveHostPosition = useCallback(
+    (index: number, direction: "up" | "down") => {
+      if (direction === "up" && index > 0) {
+        move(index, index - 1);
+      } else if (direction === "down" && index < hosts.length - 1) {
+        move(index, index + 1);
+      }
+    },
+    [move, hosts.length]
+  );
+
+  const removeHost = useCallback(
+    (index: number) => {
+      remove(index);
+    },
+    [remove]
+  );
+
+  return (
+    <AccordionPanel px={2} pb={2}>
+      <VStack gap={3}>
+        {hosts.map((host, index) => (
+          <HostRow
+            key={host.id}
+            hostId={host.id}
+            hostKey={hostKey}
+            index={index}
+            hostsLength={hosts.length}
+            duplicateHost={duplicateHost}
+            moveHostPosition={moveHostPosition}
+            removeHost={removeHost}
+            bots={bots}
+            nodes={nodes}
+            inbound={inbound}
+            inboundPort={inbound?.port}
+            accordionErrors={accordionErrors}
+            register={form.register}
+            control={form.control}
+            proxyHostSecurity={proxyHostSecurity}
+            proxyALPN={proxyALPN}
+            proxyFingerprint={proxyFingerprint}
+            t={t}
+          />
+        ))}
+
+        <Button
+          variant="outline"
+          type="button"
+          w="full"
+          size="sm"
+          fontWeight="normal"
+          onClick={handleAddHost}
+        >
+          {t("hostsDialog.addHost")}
+        </Button>
+      </VStack>
+    </AccordionPanel>
+  );
+};

--- a/app/dashboard/src/components/hostsDialog/AccordionInboundContent.tsx
+++ b/app/dashboard/src/components/hostsDialog/AccordionInboundContent.tsx
@@ -1,5 +1,5 @@
 import { Button, AccordionPanel, VStack } from "@chakra-ui/react";
-import { FC, useCallback, useEffect } from "react";
+import { FC, useCallback } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
@@ -50,17 +50,9 @@ export const AccordionInboundContent: FC<Props> = ({
   inbound,
   accordionErrors,
 }) => {
-  useEffect(() => {
-    console.log("Mounted:", hostKey);
-    return () => {
-      console.log("Unmounted:", hostKey);
-    };
-  }, []);
-
   const { t } = useTranslation();
   const form = useFormContext<z.infer<typeof hostsSchema>>();
 
-  console.log("Creating useFieldArray for", hostKey);
   const {
     fields: hosts,
     append,
@@ -122,8 +114,6 @@ export const AccordionInboundContent: FC<Props> = ({
             inbound={inbound}
             inboundPort={inbound?.port}
             accordionErrors={accordionErrors}
-            register={form.register}
-            control={form.control}
             proxyHostSecurity={proxyHostSecurity}
             proxyALPN={proxyALPN}
             proxyFingerprint={proxyFingerprint}

--- a/app/dashboard/src/components/hostsDialog/HostAdvancedOptions.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostAdvancedOptions.tsx
@@ -1,0 +1,614 @@
+import {
+  FormControl,
+  Text,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
+  VStack,
+  Badge,
+  AccordionPanel,
+  Button,
+  Checkbox,
+  AccordionIcon,
+  FormLabel,
+} from "@chakra-ui/react";
+import { NodeType } from "contexts/NodesContext";
+import { ChangeEvent, memo, useEffect } from "react";
+import { Control, Controller, UseFormRegister } from "react-hook-form";
+import { Bot } from "types/Bot";
+import { InfoIcon, Error } from "./constants";
+import { Trans } from "react-i18next";
+import { RHFInput } from "./RHFInput";
+import { RHFCheckbox } from "./RHFCheckbox";
+import { RHFSelect } from "./RHFSelect";
+
+type HostAdvancedOptionsProps = {
+  hostKey: string;
+  index: number;
+  inbound: any;
+
+  register: UseFormRegister<any>;
+  control: Control<any>;
+
+  accordionErrors: any;
+  t: any;
+
+  bots: Bot[];
+  nodes: NodeType[];
+
+  proxyHostSecurity: any[];
+  proxyALPN: any[];
+  proxyFingerprint: any[];
+};
+
+export const HostAdvancedOptions = memo(
+  ({
+    hostKey,
+    index,
+    inbound,
+    register,
+    control,
+    accordionErrors,
+    t,
+    bots,
+    nodes,
+    proxyHostSecurity,
+    proxyALPN,
+    proxyFingerprint,
+  }: HostAdvancedOptionsProps) => {
+    console.log("HostAdvancedOptions render", index);
+    useEffect(() => {
+      console.log("HostAdvancedOptions mounted", index);
+      return () => {
+        console.log("HostAdvancedOptions unmounted", index);
+      };
+    }, [index]);
+
+    return (
+      <AccordionPanel w="full" p={1}>
+        <VStack key={index} w="full" borderRadius="4px">
+          <RHFInput
+            label={t("hostsDialog.port")}
+            registerProps={register(`${hostKey}.${index}.port`)}
+            error={accordionErrors?.[index]?.port}
+            placeholder={String(inbound.port || "8080")}
+            type="number"
+            rightElement={
+              <Popover isLazy placement="right">
+                <PopoverTrigger>
+                  <InfoIcon />
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent p={2}>
+                    <PopoverArrow />
+                    <PopoverCloseButton />
+                    <Text fontSize="xs" pr={5}>
+                      {t("hostsDialog.port.info")}
+                    </Text>
+                  </PopoverContent>
+                </Portal>
+              </Popover>
+            }
+            inputProps={{
+              size: "sm",
+              borderRadius: "4px",
+            }}
+            formLabelProps={{
+              pb: 1,
+              m: 0,
+              alignItems: "center",
+              gap: 1,
+            }}
+          />
+
+          <RHFInput
+            label={t("hostsDialog.sni")}
+            registerProps={register(`${hostKey}.${index}.sni`)}
+            error={accordionErrors?.[index]?.sni}
+            placeholder="SNI (e.g. example.com)"
+            rightElement={
+              <Popover isLazy placement="right">
+                <PopoverTrigger>
+                  <InfoIcon />
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent p={2}>
+                    <PopoverArrow />
+                    <PopoverCloseButton />
+                    <Text fontSize="xs" pr={5}>
+                      {t("hostsDialog.sni.info")}
+                    </Text>
+                    <Text fontSize="xs" mt="2">
+                      <Trans
+                        i18nKey="hostsDialog.host.wildcard"
+                        components={{
+                          badge: <Badge />,
+                        }}
+                      />
+                    </Text>
+                    <Text fontSize="xs">
+                      <Trans
+                        i18nKey="hostsDialog.host.multiHost"
+                        components={{
+                          badge: <Badge />,
+                        }}
+                      />
+                    </Text>
+                  </PopoverContent>
+                </Portal>
+              </Popover>
+            }
+            inputProps={{
+              size: "sm",
+              borderRadius: "4px",
+            }}
+            formLabelProps={{
+              pb: 1,
+              m: 0,
+              alignItems: "center",
+              gap: 1,
+            }}
+          />
+
+          <RHFInput
+            label={t("hostsDialog.host")}
+            registerProps={register(`${hostKey}.${index}.host`)}
+            error={accordionErrors?.[index]?.host}
+            placeholder="Host (e.g. example.com)"
+            rightElement={
+              <Popover isLazy placement="right">
+                <PopoverTrigger>
+                  <InfoIcon />
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent p={2}>
+                    <PopoverArrow />
+                    <PopoverCloseButton />
+                    <Text fontSize="xs" pr={5}>
+                      {t("hostsDialog.host.info")}
+                    </Text>
+                    <Text fontSize="xs" mt="2">
+                      <Trans
+                        i18nKey="hostsDialog.host.wildcard"
+                        components={{
+                          badge: <Badge />,
+                        }}
+                      />
+                    </Text>
+                    <Text fontSize="xs">
+                      <Trans
+                        i18nKey="hostsDialog.host.multiHost"
+                        components={{
+                          badge: <Badge />,
+                        }}
+                      />
+                    </Text>
+                  </PopoverContent>
+                </Portal>
+              </Popover>
+            }
+            inputProps={{
+              size: "sm",
+              borderRadius: "4px",
+            }}
+          />
+
+          <RHFInput
+            label={t("hostsDialog.path")}
+            registerProps={register(`${hostKey}.${index}.path`)}
+            error={accordionErrors?.[index]?.path}
+            placeholder="path (e.g. /vless)"
+            rightElement={
+              <Popover isLazy placement="right">
+                <PopoverTrigger>
+                  <InfoIcon />
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent p={2}>
+                    <PopoverArrow />
+                    <PopoverCloseButton />
+                    <Text fontSize="xs" pr={5}>
+                      {t("hostsDialog.path.info")}
+                    </Text>
+                  </PopoverContent>
+                </Portal>
+              </Popover>
+            }
+            inputProps={{
+              size: "sm",
+              borderRadius: "4px",
+            }}
+          />
+
+          <RHFSelect
+            label={t("hostsDialog.security")}
+            registerProps={register(`${hostKey}.${index}.security`)}
+            rightElement={
+              <Popover isLazy placement="right">
+                <PopoverTrigger>
+                  <InfoIcon />
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent p={2}>
+                    <PopoverArrow />
+                    <PopoverCloseButton />
+                    <Text fontSize="xs" pr={5}>
+                      {t("hostsDialog.security.info")}
+                    </Text>
+                  </PopoverContent>
+                </Portal>
+              </Popover>
+            }
+            formControlProps={{
+              height: "66px",
+            }}
+            selectProps={{
+              size: "sm",
+            }}
+          >
+            {proxyHostSecurity.map((s) => {
+              return (
+                <option key={s.value} value={s.value}>
+                  {s.title}
+                </option>
+              );
+            })}
+          </RHFSelect>
+
+          <RHFSelect
+            label={t("hostsDialog.alpn")}
+            registerProps={register(`${hostKey}.${index}.alpn`)}
+            formControlProps={{
+              height: "66px",
+            }}
+            selectProps={{
+              size: "sm",
+            }}
+          >
+            {proxyALPN.map((s) => {
+              return (
+                <option key={s.value} value={s.value}>
+                  {s.title}
+                </option>
+              );
+            })}
+          </RHFSelect>
+
+          <RHFSelect
+            label={t("hostsDialog.fingerprint")}
+            registerProps={register(`${hostKey}.${index}.fingerprint`)}
+            formControlProps={{
+              height: "66px",
+            }}
+            selectProps={{
+              size: "sm",
+            }}
+          >
+            {proxyFingerprint.map((s) => {
+              return (
+                <option key={s.value} value={s.value}>
+                  {s.title}
+                </option>
+              );
+            })}
+          </RHFSelect>
+
+          <RHFInput
+            label={t("hostsDialog.fragment")}
+            registerProps={register(`${hostKey}.${index}.fragment_setting`)}
+            error={accordionErrors?.[index]?.fragment_setting}
+            placeholder="Fragment settings by pattern"
+            rightElement={
+              <Popover isLazy placement="right">
+                <PopoverTrigger>
+                  <InfoIcon />
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent p={2}>
+                    <PopoverArrow />
+                    <PopoverCloseButton />
+                    <Text fontSize="xs" pr={5}>
+                      {t("hostsDialog.fragment.info")}
+                    </Text>
+                    <Text fontSize="xs" pr={5} pt={2} pb={1}>
+                      {t("hostsDialog.fragment.info.examples")}
+                    </Text>
+                    <Text fontSize="xs" pr={5}>
+                      100-200,10-20,tlshello
+                    </Text>
+                    <Text fontSize="xs" pr={5}>
+                      100-200,10-20,1-3
+                    </Text>
+                    <Text fontSize="xs" pr={5} pt="3">
+                      {t("hostsDialog.fragment.info.attention")}
+                    </Text>
+                  </PopoverContent>
+                </Portal>
+              </Popover>
+            }
+            inputProps={{
+              size: "sm",
+              borderRadius: "4px",
+            }}
+          />
+
+          <RHFInput
+            label={t("hostsDialog.noise")}
+            registerProps={register(`${hostKey}.${index}.noise_setting`)}
+            error={accordionErrors?.[index]?.noise_setting}
+            placeholder="Noise settings by pattern"
+            rightElement={
+              <Popover isLazy placement="right">
+                <PopoverTrigger>
+                  <InfoIcon />
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent p={2}>
+                    <PopoverArrow />
+                    <PopoverCloseButton />
+                    <Text fontSize="xs" pr={5}>
+                      {t("hostsDialog.noise.info")}
+                    </Text>
+                    <Text fontSize="xs" pr={5} pt={2} pb={1}>
+                      {t("hostsDialog.noise.info.examples")}
+                    </Text>
+                    <Text fontSize="xs" pr={5}>
+                      rand:10-20,10-20
+                    </Text>
+                    <Text fontSize="xs" pr={5}>
+                      rand:10-20,10-20&base64:7nQBAAABAAAAAAAABnQtcmluZwZtc2VkZ2UDbmV0AAABAAE=,10-25
+                    </Text>
+                    <Text fontSize="xs" pr={5} pt="3">
+                      {t("hostsDialog.noise.info.attention")}
+                    </Text>
+                  </PopoverContent>
+                </Portal>
+              </Popover>
+            }
+            inputProps={{
+              size: "sm",
+              borderRadius: "4px",
+            }}
+          />
+
+          <RHFCheckbox
+            label={t("hostsDialog.useSniAsHost")}
+            registerProps={register(`${hostKey}.${index}.use_sni_as_host`)}
+            error={accordionErrors?.[index]?.use_sni_as_host}
+          />
+
+          <RHFCheckbox
+            label={t("hostsDialog.allowinsecure")}
+            registerProps={register(`${hostKey}.${index}.allowinsecure`)}
+            error={accordionErrors?.[index]?.allowinsecure}
+          />
+
+          <RHFCheckbox
+            label={t("hostsDialog.muxEnable")}
+            registerProps={register(`${hostKey}.${index}.mux_enable`)}
+            error={accordionErrors?.[index]?.mux_enable}
+          />
+
+          <RHFCheckbox
+            label={t("hostsDialog.randomUserAgent")}
+            registerProps={register(`${hostKey}.${index}.random_user_agent`)}
+            error={accordionErrors?.[index]?.random_user_agent}
+          />
+
+          {bots.length > 0 && (
+            <FormControl
+              isInvalid={
+                !!(accordionErrors && accordionErrors[index]?.bot_usernames)
+              }
+            >
+              <FormLabel>{t("hostsDialog.availableBots")}</FormLabel>
+              <Text
+                fontSize="xs"
+                color="gray.600"
+                _dark={{ color: "gray.400" }}
+                mb={2}
+              >
+                {t("hostsDialog.availableBots.info")}
+              </Text>
+              <Controller
+                control={control}
+                name={`${hostKey}.${index}.bot_usernames`}
+                render={({ field }) => {
+                  const selectedBotUsernames: string[] = Array.isArray(
+                    field.value
+                  )
+                    ? field.value
+                    : [];
+                  const selectedBots = bots.filter((bot: Bot) =>
+                    selectedBotUsernames.includes(bot.username)
+                  );
+
+                  return (
+                    <Popover placement="bottom-start">
+                      <PopoverTrigger>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          w="full"
+                          justifyContent="space-between"
+                        >
+                          <Text as="span" noOfLines={1}>
+                            {selectedBots.length
+                              ? t("hostsDialog.availableBots.selected", {
+                                  count: selectedBots.length,
+                                })
+                              : t("hostsDialog.availableBots.all")}
+                          </Text>
+                          <AccordionIcon />
+                        </Button>
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent
+                          w="280px"
+                          maxH="320px"
+                          overflowY="auto"
+                          zIndex={1500}
+                        >
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <PopoverBody pt={8}>
+                            <VStack align="start" spacing={2}>
+                              {bots.map((bot: Bot) => (
+                                <Checkbox
+                                  key={bot.username}
+                                  isChecked={selectedBotUsernames.includes(
+                                    bot.username
+                                  )}
+                                  onChange={(
+                                    event: ChangeEvent<HTMLInputElement>
+                                  ) => {
+                                    if (event.target.checked) {
+                                      field.onChange([
+                                        ...selectedBotUsernames,
+                                        bot.username,
+                                      ]);
+                                    } else {
+                                      field.onChange(
+                                        selectedBotUsernames.filter(
+                                          (username: string) =>
+                                            username !== bot.username
+                                        )
+                                      );
+                                    }
+                                  }}
+                                >
+                                  <Text as="span" fontSize="sm">
+                                    @{bot.username}
+                                    {bot.title ? ` (${bot.title})` : ""}
+                                  </Text>
+                                </Checkbox>
+                              ))}
+                              {selectedBotUsernames.length > 0 && (
+                                <Button
+                                  variant="ghost"
+                                  size="xs"
+                                  onClick={() => field.onChange([])}
+                                >
+                                  {t("hostsDialog.availableBots.clear")}
+                                </Button>
+                              )}
+                            </VStack>
+                          </PopoverBody>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  );
+                }}
+              />
+              {accordionErrors && accordionErrors[index]?.bot_usernames && (
+                <Error>{accordionErrors[index]?.bot_usernames?.message}</Error>
+              )}
+            </FormControl>
+          )}
+          {nodes.filter((n) => n.id != null).length > 0 && (
+            <FormControl>
+              <FormLabel>{t("hostsDialog.linkedNodes")}</FormLabel>
+              <Text
+                fontSize="xs"
+                color="gray.600"
+                _dark={{ color: "gray.400" }}
+                mb={2}
+              >
+                {t("hostsDialog.linkedNodes.info")}
+              </Text>
+              <Controller
+                control={control}
+                name={`${hostKey}.${index}.node_ids`}
+                render={({ field }) => {
+                  const selectedIds: number[] = Array.isArray(field.value)
+                    ? field.value
+                    : [];
+                  return (
+                    <Popover isLazy placement="bottom-start">
+                      <PopoverTrigger>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          w="full"
+                          justifyContent="space-between"
+                        >
+                          <Text as="span" noOfLines={1}>
+                            {selectedIds.length
+                              ? t("hostsDialog.linkedNodes.selected", {
+                                  count: selectedIds.length,
+                                })
+                              : t("hostsDialog.linkedNodes.none")}
+                          </Text>
+                          <AccordionIcon />
+                        </Button>
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent
+                          w="280px"
+                          maxH="320px"
+                          overflowY="auto"
+                          zIndex={1500}
+                        >
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <PopoverBody pt={8}>
+                            <VStack align="start" spacing={2}>
+                              {nodes
+                                .filter((n) => n.id != null)
+                                .map((node: NodeType) => {
+                                  const nodeId = node.id as number;
+                                  return (
+                                    <Checkbox
+                                      key={nodeId}
+                                      isChecked={selectedIds.includes(nodeId)}
+                                      onChange={(
+                                        event: ChangeEvent<HTMLInputElement>
+                                      ) => {
+                                        if (event.target.checked) {
+                                          field.onChange([
+                                            ...selectedIds,
+                                            nodeId,
+                                          ]);
+                                        } else {
+                                          field.onChange(
+                                            selectedIds.filter(
+                                              (id: number) => id !== nodeId
+                                            )
+                                          );
+                                        }
+                                      }}
+                                    >
+                                      <Text as="span" fontSize="sm">
+                                        {node.name}
+                                      </Text>
+                                    </Checkbox>
+                                  );
+                                })}
+                              {selectedIds.length > 0 && (
+                                <Button
+                                  variant="ghost"
+                                  size="xs"
+                                  onClick={() => field.onChange([])}
+                                >
+                                  {t("hostsDialog.linkedNodes.clear")}
+                                </Button>
+                              )}
+                            </VStack>
+                          </PopoverBody>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  );
+                }}
+              />
+            </FormControl>
+          )}
+        </VStack>
+      </AccordionPanel>
+    );
+  }
+);

--- a/app/dashboard/src/components/hostsDialog/HostAdvancedOptions.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostAdvancedOptions.tsx
@@ -30,16 +30,12 @@ type HostAdvancedOptionsProps = {
   hostKey: string;
   index: number;
   inbound: any;
-
   register: UseFormRegister<any>;
   control: Control<any>;
-
   accordionErrors: any;
   t: any;
-
   bots: Bot[];
   nodes: NodeType[];
-
   proxyHostSecurity: any[];
   proxyALPN: any[];
   proxyFingerprint: any[];
@@ -60,13 +56,7 @@ export const HostAdvancedOptions = memo(
     proxyALPN,
     proxyFingerprint,
   }: HostAdvancedOptionsProps) => {
-    console.log("HostAdvancedOptions render", index);
-    useEffect(() => {
-      console.log("HostAdvancedOptions mounted", index);
-      return () => {
-        console.log("HostAdvancedOptions unmounted", index);
-      };
-    }, [index]);
+    const portPlaceholder = inbound?.port ?? "8080";
 
     return (
       <AccordionPanel w="full" p={1}>
@@ -75,7 +65,7 @@ export const HostAdvancedOptions = memo(
             label={t("hostsDialog.port")}
             registerProps={register(`${hostKey}.${index}.port`)}
             error={accordionErrors?.[index]?.port}
-            placeholder={String(inbound.port || "8080")}
+            placeholder={String(portPlaceholder)}
             type="number"
             rightElement={
               <Popover isLazy placement="right">

--- a/app/dashboard/src/components/hostsDialog/HostInfoPopover.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostInfoPopover.tsx
@@ -1,0 +1,60 @@
+import {
+  Text,
+  Badge,
+  Box,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  Portal,
+  PopoverTrigger,
+  PopoverArrow,
+  PopoverCloseButton,
+} from "@chakra-ui/react";
+import { InfoIcon } from "./constants";
+
+export const HostInfoPopover = ({ t }: { t: any }) => (
+  <Popover isLazy placement="right">
+    <PopoverTrigger>
+      <Box mt="-8px">
+        <InfoIcon />
+      </Box>
+    </PopoverTrigger>
+
+    <Portal>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverBody>
+          <Box fontSize="xs">
+            <Text pr="20px">{t("hostsDialog.desc")}</Text>
+            {[
+              ["SERVER_IP", "currentServer"],
+              ["SERVER_IPV6", "currentServerv6"],
+              ["USERNAME", "username"],
+              ["DATA_USAGE", "dataUsage"],
+              ["DATA_LEFT", "remainingData"],
+              ["DATA_LIMIT", "dataLimit"],
+              ["DAYS_LEFT", "remainingDays"],
+              ["EXPIRE_DATE", "expireDate"],
+              ["JALALI_EXPIRE_DATE", "jalaliExpireDate"],
+              ["TIME_LEFT", "remainingTime"],
+              ["STATUS_TEXT", "statusText"],
+              ["STATUS_EMOJI", "statusEmoji"],
+              ["PROTOCOL", "proxyProtocol"],
+              ["TRANSPORT", "proxyMethod"],
+            ].map(([key, label]) => (
+              <Text key={key} mt={1}>
+                <Badge>
+                  {"{"}
+                  {key}
+                  {"}"}
+                </Badge>{" "}
+                {t(`hostsDialog.${label}`)}
+              </Text>
+            ))}
+          </Box>
+        </PopoverBody>
+      </PopoverContent>
+    </Portal>
+  </Popover>
+);

--- a/app/dashboard/src/components/hostsDialog/HostRow.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostRow.tsx
@@ -1,0 +1,795 @@
+import {
+  Box,
+  FormControl,
+  Text,
+  InputGroup,
+  InputRightElement,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
+  VStack,
+  Badge,
+  HStack,
+  Accordion,
+  AccordionItem,
+  AccordionPanel,
+  Button,
+  Checkbox,
+  AccordionIcon,
+  FormLabel,
+  AccordionButton,
+  Container,
+  Switch,
+  Tooltip,
+  IconButton,
+} from "@chakra-ui/react";
+import { NodeType } from "contexts/NodesContext";
+import { motion } from "framer-motion";
+import { ChangeEvent, memo } from "react";
+import { Control, Controller, UseFormRegister } from "react-hook-form";
+import { Bot } from "types/Bot";
+import {
+  InfoIcon,
+  Error,
+  Select,
+  DuplicateIcon,
+  DownIcon,
+  UpIcon,
+} from "./constants";
+import { DeleteIcon } from "components/DeleteUserModal";
+import { Trans } from "react-i18next";
+import { HostsInput } from "./HostsInput";
+import { RHFInput } from "./RHFInput";
+import { HostInfoPopover } from "./HostInfoPopover";
+import { RHFCheckbox } from "./RHFCheckbox";
+import { RHFSelect } from "./RHFSelect";
+
+type HostRowProps = {
+  hostKey: string;
+  index: number;
+  hostId: string;
+  bots: Bot[];
+  nodes: NodeType[];
+
+  inboundPort?: number;
+
+  accordionErrors?: any;
+
+  register: UseFormRegister<any>;
+  control: Control<any>;
+
+  t: (key: string, opts?: any) => string;
+
+  duplicateHost: (index: number) => void;
+  moveHostPosition: (index: number, direction: "up" | "down") => void;
+  removeHost: (index: number) => void;
+
+  hostsLength: number;
+  inbound: any;
+
+  proxyHostSecurity: any[];
+  proxyALPN: any[];
+  proxyFingerprint: any[];
+};
+
+export const HostRow = memo(function HostRow(props: HostRowProps) {
+  const {
+    hostKey,
+    index,
+    hostId,
+    bots,
+    nodes,
+    inbound,
+    accordionErrors,
+
+    register,
+    control,
+
+    t,
+
+    duplicateHost,
+    moveHostPosition,
+    removeHost,
+
+    hostsLength,
+    proxyHostSecurity,
+    proxyALPN,
+    proxyFingerprint,
+  } = props;
+
+  return (
+    <motion.div
+      key={hostId}
+      layout
+      initial={false}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{
+        layout: { type: "spring", stiffness: 500, damping: 30 },
+        opacity: { duration: 0.1 },
+      }}
+      id={hostId}
+      whileDrag={{ scale: 1.05, zIndex: 10 }}
+      style={{ width: "100%" }}
+    >
+      <VStack border="1px solid" p={2} w="full" borderRadius="4px">
+        <HStack w="100%" alignItems="flex-start">
+          <RHFInput
+            label="Remark"
+            registerProps={register(`${hostKey}.${index}.remark`)}
+            error={accordionErrors?.[index]?.remark}
+            rightElement={<HostInfoPopover t={t} />}
+            formControlProps={{
+              position: "relative",
+              zIndex: 10,
+            }}
+            inputProps={{
+              size: "sm",
+              borderRadius: "4px",
+            }}
+          />
+        </HStack>
+
+        <RHFInput
+          label="Address"
+          registerProps={register(`${hostKey}.${index}.address`)}
+          error={accordionErrors?.[index]?.address}
+          placeholder="example.com"
+          rightElement={<HostInfoPopover t={t} />}
+          formControlProps={{
+            isInvalid: !!accordionErrors?.[index]?.address,
+          }}
+        />
+
+        <Accordion w="full" allowToggle>
+          <AccordionItem border="0">
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <AccordionButton
+                display="flex"
+                px={0}
+                py={1}
+                borderRadius={3}
+                _hover={{ bg: "transparent" }}
+              >
+                <Text
+                  flex="3"
+                  align="start"
+                  fontSize="xs"
+                  color="gray.600"
+                  _dark={{ color: "gray.500" }}
+                  pl={1}
+                >
+                  {t("hostsDialog.advancedOptions")}
+                  <AccordionIcon fontSize="sm" ml={1} />
+                </Text>
+
+                <Container flex="1" px="0" display={"contents"}>
+                  <Controller
+                    control={control}
+                    name={`${hostKey}.${index}.is_disabled`}
+                    render={({ field }) => {
+                      return (
+                        <Switch
+                          mx="1.5"
+                          colorScheme="primary"
+                          isChecked={!!field.value}
+                          onChange={(e) => field.onChange(e.target.checked)}
+                        />
+                      );
+                    }}
+                  />
+                  <Tooltip label="Delete" placement="top">
+                    <IconButton
+                      aria-label="Delete"
+                      size="sm"
+                      colorScheme="red"
+                      variant="ghost"
+                      onClick={removeHost.bind(null, index)}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Tooltip>
+                </Container>
+              </AccordionButton>
+              <Tooltip label="Duplicate" placement="top">
+                <IconButton
+                  aria-label="Duplicate"
+                  size="sm"
+                  colorScheme="white"
+                  variant="ghost"
+                  onClick={() => duplicateHost(index)}
+                >
+                  <DuplicateIcon />
+                </IconButton>
+              </Tooltip>
+              {index < hostsLength - 1 && (
+                <Tooltip label="Move Down" placement="top">
+                  <IconButton
+                    aria-label="DownIcon"
+                    size="sm"
+                    colorScheme="white"
+                    variant="ghost"
+                    onClick={() => moveHostPosition(index, "down")}
+                  >
+                    <DownIcon />
+                  </IconButton>
+                </Tooltip>
+              )}
+              {index > 0 && (
+                <Tooltip label="Move Up" placement="top">
+                  <IconButton
+                    aria-label="UpIcon"
+                    size="sm"
+                    colorScheme="white"
+                    variant="ghost"
+                    onClick={() => moveHostPosition(index, "up")}
+                  >
+                    <UpIcon />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </div>
+            <AccordionPanel w="full" p={1}>
+              <VStack key={index} w="full" borderRadius="4px">
+                <RHFInput
+                  label={t("hostsDialog.port")}
+                  registerProps={register(`${hostKey}.${index}.port`)}
+                  error={accordionErrors?.[index]?.port}
+                  placeholder={String(inbound.port || "8080")}
+                  type="number"
+                  rightElement={
+                    <Popover isLazy placement="right">
+                      <PopoverTrigger>
+                        <InfoIcon />
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent p={2}>
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <Text fontSize="xs" pr={5}>
+                            {t("hostsDialog.port.info")}
+                          </Text>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  }
+                  inputProps={{
+                    size: "sm",
+                    borderRadius: "4px",
+                  }}
+                  formLabelProps={{
+                    pb: 1,
+                    m: 0,
+                    alignItems: "center",
+                    gap: 1,
+                  }}
+                />
+
+                <RHFInput
+                  label={t("hostsDialog.sni")}
+                  registerProps={register(`${hostKey}.${index}.sni`)}
+                  error={accordionErrors?.[index]?.sni}
+                  placeholder="SNI (e.g. example.com)"
+                  rightElement={
+                    <Popover isLazy placement="right">
+                      <PopoverTrigger>
+                        <InfoIcon />
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent p={2}>
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <Text fontSize="xs" pr={5}>
+                            {t("hostsDialog.sni.info")}
+                          </Text>
+                          <Text fontSize="xs" mt="2">
+                            <Trans
+                              i18nKey="hostsDialog.host.wildcard"
+                              components={{
+                                badge: <Badge />,
+                              }}
+                            />
+                          </Text>
+                          <Text fontSize="xs">
+                            <Trans
+                              i18nKey="hostsDialog.host.multiHost"
+                              components={{
+                                badge: <Badge />,
+                              }}
+                            />
+                          </Text>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  }
+                  inputProps={{
+                    size: "sm",
+                    borderRadius: "4px",
+                  }}
+                  formLabelProps={{
+                    pb: 1,
+                    m: 0,
+                    alignItems: "center",
+                    gap: 1,
+                  }}
+                />
+
+                <RHFInput
+                  label={t("hostsDialog.host")}
+                  registerProps={register(`${hostKey}.${index}.host`)}
+                  error={accordionErrors?.[index]?.host}
+                  placeholder="Host (e.g. example.com)"
+                  rightElement={
+                    <Popover isLazy placement="right">
+                      <PopoverTrigger>
+                        <InfoIcon />
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent p={2}>
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <Text fontSize="xs" pr={5}>
+                            {t("hostsDialog.host.info")}
+                          </Text>
+                          <Text fontSize="xs" mt="2">
+                            <Trans
+                              i18nKey="hostsDialog.host.wildcard"
+                              components={{
+                                badge: <Badge />,
+                              }}
+                            />
+                          </Text>
+                          <Text fontSize="xs">
+                            <Trans
+                              i18nKey="hostsDialog.host.multiHost"
+                              components={{
+                                badge: <Badge />,
+                              }}
+                            />
+                          </Text>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  }
+                  inputProps={{
+                    size: "sm",
+                    borderRadius: "4px",
+                  }}
+                />
+
+                <RHFInput
+                  label={t("hostsDialog.path")}
+                  registerProps={register(`${hostKey}.${index}.path`)}
+                  error={accordionErrors?.[index]?.path}
+                  placeholder="path (e.g. /vless)"
+                  rightElement={
+                    <Popover isLazy placement="right">
+                      <PopoverTrigger>
+                        <InfoIcon />
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent p={2}>
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <Text fontSize="xs" pr={5}>
+                            {t("hostsDialog.path.info")}
+                          </Text>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  }
+                  inputProps={{
+                    size: "sm",
+                    borderRadius: "4px",
+                  }}
+                />
+
+                <RHFSelect
+                  label={t("hostsDialog.security")}
+                  registerProps={register(`${hostKey}.${index}.security`)}
+                  rightElement={
+                    <Popover isLazy placement="right">
+                      <PopoverTrigger>
+                        <InfoIcon />
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent p={2}>
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <Text fontSize="xs" pr={5}>
+                            {t("hostsDialog.security.info")}
+                          </Text>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  }
+                  formControlProps={{
+                    height: "66px",
+                  }}
+                  selectProps={{
+                    size: "sm",
+                  }}
+                >
+                  {proxyHostSecurity.map((s) => {
+                    return (
+                      <option key={s.value} value={s.value}>
+                        {s.title}
+                      </option>
+                    );
+                  })}
+                </RHFSelect>
+
+                <RHFSelect
+                  label={t("hostsDialog.alpn")}
+                  registerProps={register(`${hostKey}.${index}.alpn`)}
+                  formControlProps={{
+                    height: "66px",
+                  }}
+                  selectProps={{
+                    size: "sm",
+                  }}
+                >
+                  {proxyALPN.map((s) => {
+                    return (
+                      <option key={s.value} value={s.value}>
+                        {s.title}
+                      </option>
+                    );
+                  })}
+                </RHFSelect>
+
+                <RHFSelect
+                  label={t("hostsDialog.fingerprint")}
+                  registerProps={register(`${hostKey}.${index}.fingerprint`)}
+                  formControlProps={{
+                    height: "66px",
+                  }}
+                  selectProps={{
+                    size: "sm",
+                  }}
+                >
+                  {proxyFingerprint.map((s) => {
+                    return (
+                      <option key={s.value} value={s.value}>
+                        {s.title}
+                      </option>
+                    );
+                  })}
+                </RHFSelect>
+
+                <RHFInput
+                  label={t("hostsDialog.fragment")}
+                  registerProps={register(
+                    `${hostKey}.${index}.fragment_setting`
+                  )}
+                  error={accordionErrors?.[index]?.fragment_setting}
+                  placeholder="Fragment settings by pattern"
+                  rightElement={
+                    <Popover isLazy placement="right">
+                      <PopoverTrigger>
+                        <InfoIcon />
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent p={2}>
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <Text fontSize="xs" pr={5}>
+                            {t("hostsDialog.fragment.info")}
+                          </Text>
+                          <Text fontSize="xs" pr={5} pt={2} pb={1}>
+                            {t("hostsDialog.fragment.info.examples")}
+                          </Text>
+                          <Text fontSize="xs" pr={5}>
+                            100-200,10-20,tlshello
+                          </Text>
+                          <Text fontSize="xs" pr={5}>
+                            100-200,10-20,1-3
+                          </Text>
+                          <Text fontSize="xs" pr={5} pt="3">
+                            {t("hostsDialog.fragment.info.attention")}
+                          </Text>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  }
+                  inputProps={{
+                    size: "sm",
+                    borderRadius: "4px",
+                  }}
+                />
+
+                <RHFInput
+                  label={t("hostsDialog.noise")}
+                  registerProps={register(`${hostKey}.${index}.noise_setting`)}
+                  error={accordionErrors?.[index]?.noise_setting}
+                  placeholder="Noise settings by pattern"
+                  rightElement={
+                    <Popover isLazy placement="right">
+                      <PopoverTrigger>
+                        <InfoIcon />
+                      </PopoverTrigger>
+                      <Portal>
+                        <PopoverContent p={2}>
+                          <PopoverArrow />
+                          <PopoverCloseButton />
+                          <Text fontSize="xs" pr={5}>
+                            {t("hostsDialog.noise.info")}
+                          </Text>
+                          <Text fontSize="xs" pr={5} pt={2} pb={1}>
+                            {t("hostsDialog.noise.info.examples")}
+                          </Text>
+                          <Text fontSize="xs" pr={5}>
+                            rand:10-20,10-20
+                          </Text>
+                          <Text fontSize="xs" pr={5}>
+                            rand:10-20,10-20&base64:7nQBAAABAAAAAAAABnQtcmluZwZtc2VkZ2UDbmV0AAABAAE=,10-25
+                          </Text>
+                          <Text fontSize="xs" pr={5} pt="3">
+                            {t("hostsDialog.noise.info.attention")}
+                          </Text>
+                        </PopoverContent>
+                      </Portal>
+                    </Popover>
+                  }
+                  inputProps={{
+                    size: "sm",
+                    borderRadius: "4px",
+                  }}
+                />
+
+                <RHFCheckbox
+                  label={t("hostsDialog.useSniAsHost")}
+                  registerProps={register(
+                    `${hostKey}.${index}.use_sni_as_host`
+                  )}
+                  error={accordionErrors?.[index]?.use_sni_as_host}
+                />
+
+                <RHFCheckbox
+                  label={t("hostsDialog.allowinsecure")}
+                  registerProps={register(`${hostKey}.${index}.allowinsecure`)}
+                  error={accordionErrors?.[index]?.allowinsecure}
+                />
+
+                <RHFCheckbox
+                  label={t("hostsDialog.muxEnable")}
+                  registerProps={register(`${hostKey}.${index}.mux_enable`)}
+                  error={accordionErrors?.[index]?.mux_enable}
+                />
+
+                <RHFCheckbox
+                  label={t("hostsDialog.randomUserAgent")}
+                  registerProps={register(
+                    `${hostKey}.${index}.random_user_agent`
+                  )}
+                  error={accordionErrors?.[index]?.random_user_agent}
+                />
+
+                {bots.length > 0 && (
+                  <FormControl
+                    isInvalid={
+                      !!(
+                        accordionErrors && accordionErrors[index]?.bot_usernames
+                      )
+                    }
+                  >
+                    <FormLabel>{t("hostsDialog.availableBots")}</FormLabel>
+                    <Text
+                      fontSize="xs"
+                      color="gray.600"
+                      _dark={{ color: "gray.400" }}
+                      mb={2}
+                    >
+                      {t("hostsDialog.availableBots.info")}
+                    </Text>
+                    <Controller
+                      control={control}
+                      name={`${hostKey}.${index}.bot_usernames`}
+                      render={({ field }) => {
+                        const selectedBotUsernames: string[] = Array.isArray(
+                          field.value
+                        )
+                          ? field.value
+                          : [];
+                        const selectedBots = bots.filter((bot: Bot) =>
+                          selectedBotUsernames.includes(bot.username)
+                        );
+
+                        return (
+                          <Popover placement="bottom-start">
+                            <PopoverTrigger>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                w="full"
+                                justifyContent="space-between"
+                              >
+                                <Text as="span" noOfLines={1}>
+                                  {selectedBots.length
+                                    ? t("hostsDialog.availableBots.selected", {
+                                        count: selectedBots.length,
+                                      })
+                                    : t("hostsDialog.availableBots.all")}
+                                </Text>
+                                <AccordionIcon />
+                              </Button>
+                            </PopoverTrigger>
+                            <Portal>
+                              <PopoverContent
+                                w="280px"
+                                maxH="320px"
+                                overflowY="auto"
+                                zIndex={1500}
+                              >
+                                <PopoverArrow />
+                                <PopoverCloseButton />
+                                <PopoverBody pt={8}>
+                                  <VStack align="start" spacing={2}>
+                                    {bots.map((bot: Bot) => (
+                                      <Checkbox
+                                        key={bot.username}
+                                        isChecked={selectedBotUsernames.includes(
+                                          bot.username
+                                        )}
+                                        onChange={(
+                                          event: ChangeEvent<HTMLInputElement>
+                                        ) => {
+                                          if (event.target.checked) {
+                                            field.onChange([
+                                              ...selectedBotUsernames,
+                                              bot.username,
+                                            ]);
+                                          } else {
+                                            field.onChange(
+                                              selectedBotUsernames.filter(
+                                                (username: string) =>
+                                                  username !== bot.username
+                                              )
+                                            );
+                                          }
+                                        }}
+                                      >
+                                        <Text as="span" fontSize="sm">
+                                          @{bot.username}
+                                          {bot.title ? ` (${bot.title})` : ""}
+                                        </Text>
+                                      </Checkbox>
+                                    ))}
+                                    {selectedBotUsernames.length > 0 && (
+                                      <Button
+                                        variant="ghost"
+                                        size="xs"
+                                        onClick={() => field.onChange([])}
+                                      >
+                                        {t("hostsDialog.availableBots.clear")}
+                                      </Button>
+                                    )}
+                                  </VStack>
+                                </PopoverBody>
+                              </PopoverContent>
+                            </Portal>
+                          </Popover>
+                        );
+                      }}
+                    />
+                    {accordionErrors &&
+                      accordionErrors[index]?.bot_usernames && (
+                        <Error>
+                          {accordionErrors[index]?.bot_usernames?.message}
+                        </Error>
+                      )}
+                  </FormControl>
+                )}
+                {nodes.filter((n) => n.id != null).length > 0 && (
+                  <FormControl>
+                    <FormLabel>{t("hostsDialog.linkedNodes")}</FormLabel>
+                    <Text
+                      fontSize="xs"
+                      color="gray.600"
+                      _dark={{ color: "gray.400" }}
+                      mb={2}
+                    >
+                      {t("hostsDialog.linkedNodes.info")}
+                    </Text>
+                    <Controller
+                      control={control}
+                      name={`${hostKey}.${index}.node_ids`}
+                      render={({ field }) => {
+                        const selectedIds: number[] = Array.isArray(field.value)
+                          ? field.value
+                          : [];
+                        return (
+                          <Popover isLazy placement="bottom-start">
+                            <PopoverTrigger>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                w="full"
+                                justifyContent="space-between"
+                              >
+                                <Text as="span" noOfLines={1}>
+                                  {selectedIds.length
+                                    ? t("hostsDialog.linkedNodes.selected", {
+                                        count: selectedIds.length,
+                                      })
+                                    : t("hostsDialog.linkedNodes.none")}
+                                </Text>
+                                <AccordionIcon />
+                              </Button>
+                            </PopoverTrigger>
+                            <Portal>
+                              <PopoverContent
+                                w="280px"
+                                maxH="320px"
+                                overflowY="auto"
+                                zIndex={1500}
+                              >
+                                <PopoverArrow />
+                                <PopoverCloseButton />
+                                <PopoverBody pt={8}>
+                                  <VStack align="start" spacing={2}>
+                                    {nodes
+                                      .filter((n) => n.id != null)
+                                      .map((node: NodeType) => {
+                                        const nodeId = node.id as number;
+                                        return (
+                                          <Checkbox
+                                            key={nodeId}
+                                            isChecked={selectedIds.includes(
+                                              nodeId
+                                            )}
+                                            onChange={(
+                                              event: ChangeEvent<HTMLInputElement>
+                                            ) => {
+                                              if (event.target.checked) {
+                                                field.onChange([
+                                                  ...selectedIds,
+                                                  nodeId,
+                                                ]);
+                                              } else {
+                                                field.onChange(
+                                                  selectedIds.filter(
+                                                    (id: number) =>
+                                                      id !== nodeId
+                                                  )
+                                                );
+                                              }
+                                            }}
+                                          >
+                                            <Text as="span" fontSize="sm">
+                                              {node.name}
+                                            </Text>
+                                          </Checkbox>
+                                        );
+                                      })}
+                                    {selectedIds.length > 0 && (
+                                      <Button
+                                        variant="ghost"
+                                        size="xs"
+                                        onClick={() => field.onChange([])}
+                                      >
+                                        {t("hostsDialog.linkedNodes.clear")}
+                                      </Button>
+                                    )}
+                                  </VStack>
+                                </PopoverBody>
+                              </PopoverContent>
+                            </Portal>
+                          </Popover>
+                        );
+                      }}
+                    />
+                  </FormControl>
+                )}
+              </VStack>
+            </AccordionPanel>
+          </AccordionItem>
+        </Accordion>
+      </VStack>
+    </motion.div>
+  );
+});

--- a/app/dashboard/src/components/hostsDialog/HostRow.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostRow.tsx
@@ -13,14 +13,16 @@ import {
 } from "@chakra-ui/react";
 import { NodeType } from "contexts/NodesContext";
 import { motion } from "framer-motion";
-import { memo, useState } from "react";
-import { Control, Controller, UseFormRegister } from "react-hook-form";
+import { memo } from "react";
+import { Controller, useFormContext } from "react-hook-form";
 import { Bot } from "types/Bot";
 import { DuplicateIcon, DownIcon, UpIcon } from "./constants";
 import { DeleteIcon } from "components/DeleteUserModal";
 import { RHFInput } from "./RHFInput";
 import { HostInfoPopover } from "./HostInfoPopover";
 import { HostAdvancedOptions } from "./HostAdvancedOptions";
+import { hostsSchema } from "./schema";
+import { z } from "zod";
 
 type HostRowProps = {
   hostKey: string;
@@ -28,29 +30,21 @@ type HostRowProps = {
   hostId: string;
   bots: Bot[];
   nodes: NodeType[];
-
   inboundPort?: number;
-
   accordionErrors?: any;
-
-  register: UseFormRegister<any>;
-  control: Control<any>;
-
   t: (key: string, opts?: any) => string;
-
   duplicateHost: (index: number) => void;
   moveHostPosition: (index: number, direction: "up" | "down") => void;
   removeHost: (index: number) => void;
-
   hostsLength: number;
   inbound: any;
-
   proxyHostSecurity: any[];
   proxyALPN: any[];
   proxyFingerprint: any[];
 };
 
 export const HostRow = memo(function HostRow(props: HostRowProps) {
+  const { register, control } = useFormContext<z.infer<typeof hostsSchema>>();
   const {
     hostKey,
     index,
@@ -59,22 +53,15 @@ export const HostRow = memo(function HostRow(props: HostRowProps) {
     nodes,
     inbound,
     accordionErrors,
-
-    register,
-    control,
-
     t,
-
     duplicateHost,
     moveHostPosition,
     removeHost,
-
     hostsLength,
     proxyHostSecurity,
     proxyALPN,
     proxyFingerprint,
   } = props;
-  console.log("Render HostRow", hostKey, index);
 
   return (
     <motion.div
@@ -121,108 +108,6 @@ export const HostRow = memo(function HostRow(props: HostRowProps) {
         />
 
         <Accordion w="full" allowToggle>
-          {/* <AccordionItem border="0">
-            <div style={{ display: "flex", alignItems: "center" }}>
-              <AccordionButton
-                display="flex"
-                px={0}
-                py={1}
-                borderRadius={3}
-                _hover={{ bg: "transparent" }}
-              >
-                <Text
-                  flex="3"
-                  align="start"
-                  fontSize="xs"
-                  color="gray.600"
-                  _dark={{ color: "gray.500" }}
-                  pl={1}
-                >
-                  {t("hostsDialog.advancedOptions")}
-                  <AccordionIcon fontSize="sm" ml={1} />
-                </Text>
-
-                <Container flex="1" px="0" display={"contents"}>
-                  <Controller
-                    control={control}
-                    name={`${hostKey}.${index}.is_disabled`}
-                    render={({ field }) => {
-                      return (
-                        <Switch
-                          mx="1.5"
-                          colorScheme="primary"
-                          isChecked={!!field.value}
-                          onChange={(e) => field.onChange(e.target.checked)}
-                        />
-                      );
-                    }}
-                  />
-                  <Tooltip label="Delete" placement="top">
-                    <IconButton
-                      aria-label="Delete"
-                      size="sm"
-                      colorScheme="red"
-                      variant="ghost"
-                      onClick={removeHost.bind(null, index)}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </Tooltip>
-                </Container>
-              </AccordionButton>
-              <Tooltip label="Duplicate" placement="top">
-                <IconButton
-                  aria-label="Duplicate"
-                  size="sm"
-                  colorScheme="white"
-                  variant="ghost"
-                  onClick={() => duplicateHost(index)}
-                >
-                  <DuplicateIcon />
-                </IconButton>
-              </Tooltip>
-              {index < hostsLength - 1 && (
-                <Tooltip label="Move Down" placement="top">
-                  <IconButton
-                    aria-label="DownIcon"
-                    size="sm"
-                    colorScheme="white"
-                    variant="ghost"
-                    onClick={() => moveHostPosition(index, "down")}
-                  >
-                    <DownIcon />
-                  </IconButton>
-                </Tooltip>
-              )}
-              {index > 0 && (
-                <Tooltip label="Move Up" placement="top">
-                  <IconButton
-                    aria-label="UpIcon"
-                    size="sm"
-                    colorScheme="white"
-                    variant="ghost"
-                    onClick={() => moveHostPosition(index, "up")}
-                  >
-                    <UpIcon />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </div>
-            <HostAdvancedOptions
-              hostKey={hostKey}
-              index={index}
-              inbound={inbound}
-              register={register}
-              control={control}
-              accordionErrors={accordionErrors}
-              t={t}
-              bots={bots}
-              nodes={nodes}
-              proxyHostSecurity={proxyHostSecurity}
-              proxyALPN={proxyALPN}
-              proxyFingerprint={proxyFingerprint}
-            />
-          </AccordionItem> */}
           <AccordionItem border="0">
             {({ isExpanded }) => (
               <>

--- a/app/dashboard/src/components/hostsDialog/HostRow.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostRow.tsx
@@ -78,7 +78,7 @@ export const HostRow = memo(function HostRow(props: HostRowProps) {
       whileDrag={{ scale: 1.05, zIndex: 10 }}
       style={{ width: "100%" }}
     >
-      <VStack border="1px solid" p={2} w="full" borderRadius="4px">
+      <VStack p={2} w="full" borderRadius="4px">
         <HStack w="100%" alignItems="flex-start">
           <RHFInput
             label="Remark"
@@ -140,8 +140,10 @@ export const HostRow = memo(function HostRow(props: HostRowProps) {
                             <Switch
                               mx="1.5"
                               colorScheme="primary"
-                              isChecked={!!field.value}
-                              onChange={(e) => field.onChange(e.target.checked)}
+                              isChecked={!field.value}
+                              onChange={(e) =>
+                                field.onChange(!e.target.checked)
+                              }
                             />
                           );
                         }}

--- a/app/dashboard/src/components/hostsDialog/HostRow.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostRow.tsx
@@ -1,26 +1,10 @@
 import {
-  Box,
-  FormControl,
   Text,
-  InputGroup,
-  InputRightElement,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverCloseButton,
-  PopoverContent,
-  PopoverTrigger,
-  Portal,
   VStack,
-  Badge,
   HStack,
   Accordion,
   AccordionItem,
-  AccordionPanel,
-  Button,
-  Checkbox,
   AccordionIcon,
-  FormLabel,
   AccordionButton,
   Container,
   Switch,
@@ -29,24 +13,14 @@ import {
 } from "@chakra-ui/react";
 import { NodeType } from "contexts/NodesContext";
 import { motion } from "framer-motion";
-import { ChangeEvent, memo } from "react";
+import { memo, useState } from "react";
 import { Control, Controller, UseFormRegister } from "react-hook-form";
 import { Bot } from "types/Bot";
-import {
-  InfoIcon,
-  Error,
-  Select,
-  DuplicateIcon,
-  DownIcon,
-  UpIcon,
-} from "./constants";
+import { DuplicateIcon, DownIcon, UpIcon } from "./constants";
 import { DeleteIcon } from "components/DeleteUserModal";
-import { Trans } from "react-i18next";
-import { HostsInput } from "./HostsInput";
 import { RHFInput } from "./RHFInput";
 import { HostInfoPopover } from "./HostInfoPopover";
-import { RHFCheckbox } from "./RHFCheckbox";
-import { RHFSelect } from "./RHFSelect";
+import { HostAdvancedOptions } from "./HostAdvancedOptions";
 
 type HostRowProps = {
   hostKey: string;
@@ -100,6 +74,7 @@ export const HostRow = memo(function HostRow(props: HostRowProps) {
     proxyALPN,
     proxyFingerprint,
   } = props;
+  console.log("Render HostRow", hostKey, index);
 
   return (
     <motion.div
@@ -146,7 +121,7 @@ export const HostRow = memo(function HostRow(props: HostRowProps) {
         />
 
         <Accordion w="full" allowToggle>
-          <AccordionItem border="0">
+          {/* <AccordionItem border="0">
             <div style={{ display: "flex", alignItems: "center" }}>
               <AccordionButton
                 display="flex"
@@ -233,560 +208,129 @@ export const HostRow = memo(function HostRow(props: HostRowProps) {
                 </Tooltip>
               )}
             </div>
-            <AccordionPanel w="full" p={1}>
-              <VStack key={index} w="full" borderRadius="4px">
-                <RHFInput
-                  label={t("hostsDialog.port")}
-                  registerProps={register(`${hostKey}.${index}.port`)}
-                  error={accordionErrors?.[index]?.port}
-                  placeholder={String(inbound.port || "8080")}
-                  type="number"
-                  rightElement={
-                    <Popover isLazy placement="right">
-                      <PopoverTrigger>
-                        <InfoIcon />
-                      </PopoverTrigger>
-                      <Portal>
-                        <PopoverContent p={2}>
-                          <PopoverArrow />
-                          <PopoverCloseButton />
-                          <Text fontSize="xs" pr={5}>
-                            {t("hostsDialog.port.info")}
-                          </Text>
-                        </PopoverContent>
-                      </Portal>
-                    </Popover>
-                  }
-                  inputProps={{
-                    size: "sm",
-                    borderRadius: "4px",
-                  }}
-                  formLabelProps={{
-                    pb: 1,
-                    m: 0,
-                    alignItems: "center",
-                    gap: 1,
-                  }}
-                />
-
-                <RHFInput
-                  label={t("hostsDialog.sni")}
-                  registerProps={register(`${hostKey}.${index}.sni`)}
-                  error={accordionErrors?.[index]?.sni}
-                  placeholder="SNI (e.g. example.com)"
-                  rightElement={
-                    <Popover isLazy placement="right">
-                      <PopoverTrigger>
-                        <InfoIcon />
-                      </PopoverTrigger>
-                      <Portal>
-                        <PopoverContent p={2}>
-                          <PopoverArrow />
-                          <PopoverCloseButton />
-                          <Text fontSize="xs" pr={5}>
-                            {t("hostsDialog.sni.info")}
-                          </Text>
-                          <Text fontSize="xs" mt="2">
-                            <Trans
-                              i18nKey="hostsDialog.host.wildcard"
-                              components={{
-                                badge: <Badge />,
-                              }}
-                            />
-                          </Text>
-                          <Text fontSize="xs">
-                            <Trans
-                              i18nKey="hostsDialog.host.multiHost"
-                              components={{
-                                badge: <Badge />,
-                              }}
-                            />
-                          </Text>
-                        </PopoverContent>
-                      </Portal>
-                    </Popover>
-                  }
-                  inputProps={{
-                    size: "sm",
-                    borderRadius: "4px",
-                  }}
-                  formLabelProps={{
-                    pb: 1,
-                    m: 0,
-                    alignItems: "center",
-                    gap: 1,
-                  }}
-                />
-
-                <RHFInput
-                  label={t("hostsDialog.host")}
-                  registerProps={register(`${hostKey}.${index}.host`)}
-                  error={accordionErrors?.[index]?.host}
-                  placeholder="Host (e.g. example.com)"
-                  rightElement={
-                    <Popover isLazy placement="right">
-                      <PopoverTrigger>
-                        <InfoIcon />
-                      </PopoverTrigger>
-                      <Portal>
-                        <PopoverContent p={2}>
-                          <PopoverArrow />
-                          <PopoverCloseButton />
-                          <Text fontSize="xs" pr={5}>
-                            {t("hostsDialog.host.info")}
-                          </Text>
-                          <Text fontSize="xs" mt="2">
-                            <Trans
-                              i18nKey="hostsDialog.host.wildcard"
-                              components={{
-                                badge: <Badge />,
-                              }}
-                            />
-                          </Text>
-                          <Text fontSize="xs">
-                            <Trans
-                              i18nKey="hostsDialog.host.multiHost"
-                              components={{
-                                badge: <Badge />,
-                              }}
-                            />
-                          </Text>
-                        </PopoverContent>
-                      </Portal>
-                    </Popover>
-                  }
-                  inputProps={{
-                    size: "sm",
-                    borderRadius: "4px",
-                  }}
-                />
-
-                <RHFInput
-                  label={t("hostsDialog.path")}
-                  registerProps={register(`${hostKey}.${index}.path`)}
-                  error={accordionErrors?.[index]?.path}
-                  placeholder="path (e.g. /vless)"
-                  rightElement={
-                    <Popover isLazy placement="right">
-                      <PopoverTrigger>
-                        <InfoIcon />
-                      </PopoverTrigger>
-                      <Portal>
-                        <PopoverContent p={2}>
-                          <PopoverArrow />
-                          <PopoverCloseButton />
-                          <Text fontSize="xs" pr={5}>
-                            {t("hostsDialog.path.info")}
-                          </Text>
-                        </PopoverContent>
-                      </Portal>
-                    </Popover>
-                  }
-                  inputProps={{
-                    size: "sm",
-                    borderRadius: "4px",
-                  }}
-                />
-
-                <RHFSelect
-                  label={t("hostsDialog.security")}
-                  registerProps={register(`${hostKey}.${index}.security`)}
-                  rightElement={
-                    <Popover isLazy placement="right">
-                      <PopoverTrigger>
-                        <InfoIcon />
-                      </PopoverTrigger>
-                      <Portal>
-                        <PopoverContent p={2}>
-                          <PopoverArrow />
-                          <PopoverCloseButton />
-                          <Text fontSize="xs" pr={5}>
-                            {t("hostsDialog.security.info")}
-                          </Text>
-                        </PopoverContent>
-                      </Portal>
-                    </Popover>
-                  }
-                  formControlProps={{
-                    height: "66px",
-                  }}
-                  selectProps={{
-                    size: "sm",
-                  }}
-                >
-                  {proxyHostSecurity.map((s) => {
-                    return (
-                      <option key={s.value} value={s.value}>
-                        {s.title}
-                      </option>
-                    );
-                  })}
-                </RHFSelect>
-
-                <RHFSelect
-                  label={t("hostsDialog.alpn")}
-                  registerProps={register(`${hostKey}.${index}.alpn`)}
-                  formControlProps={{
-                    height: "66px",
-                  }}
-                  selectProps={{
-                    size: "sm",
-                  }}
-                >
-                  {proxyALPN.map((s) => {
-                    return (
-                      <option key={s.value} value={s.value}>
-                        {s.title}
-                      </option>
-                    );
-                  })}
-                </RHFSelect>
-
-                <RHFSelect
-                  label={t("hostsDialog.fingerprint")}
-                  registerProps={register(`${hostKey}.${index}.fingerprint`)}
-                  formControlProps={{
-                    height: "66px",
-                  }}
-                  selectProps={{
-                    size: "sm",
-                  }}
-                >
-                  {proxyFingerprint.map((s) => {
-                    return (
-                      <option key={s.value} value={s.value}>
-                        {s.title}
-                      </option>
-                    );
-                  })}
-                </RHFSelect>
-
-                <RHFInput
-                  label={t("hostsDialog.fragment")}
-                  registerProps={register(
-                    `${hostKey}.${index}.fragment_setting`
-                  )}
-                  error={accordionErrors?.[index]?.fragment_setting}
-                  placeholder="Fragment settings by pattern"
-                  rightElement={
-                    <Popover isLazy placement="right">
-                      <PopoverTrigger>
-                        <InfoIcon />
-                      </PopoverTrigger>
-                      <Portal>
-                        <PopoverContent p={2}>
-                          <PopoverArrow />
-                          <PopoverCloseButton />
-                          <Text fontSize="xs" pr={5}>
-                            {t("hostsDialog.fragment.info")}
-                          </Text>
-                          <Text fontSize="xs" pr={5} pt={2} pb={1}>
-                            {t("hostsDialog.fragment.info.examples")}
-                          </Text>
-                          <Text fontSize="xs" pr={5}>
-                            100-200,10-20,tlshello
-                          </Text>
-                          <Text fontSize="xs" pr={5}>
-                            100-200,10-20,1-3
-                          </Text>
-                          <Text fontSize="xs" pr={5} pt="3">
-                            {t("hostsDialog.fragment.info.attention")}
-                          </Text>
-                        </PopoverContent>
-                      </Portal>
-                    </Popover>
-                  }
-                  inputProps={{
-                    size: "sm",
-                    borderRadius: "4px",
-                  }}
-                />
-
-                <RHFInput
-                  label={t("hostsDialog.noise")}
-                  registerProps={register(`${hostKey}.${index}.noise_setting`)}
-                  error={accordionErrors?.[index]?.noise_setting}
-                  placeholder="Noise settings by pattern"
-                  rightElement={
-                    <Popover isLazy placement="right">
-                      <PopoverTrigger>
-                        <InfoIcon />
-                      </PopoverTrigger>
-                      <Portal>
-                        <PopoverContent p={2}>
-                          <PopoverArrow />
-                          <PopoverCloseButton />
-                          <Text fontSize="xs" pr={5}>
-                            {t("hostsDialog.noise.info")}
-                          </Text>
-                          <Text fontSize="xs" pr={5} pt={2} pb={1}>
-                            {t("hostsDialog.noise.info.examples")}
-                          </Text>
-                          <Text fontSize="xs" pr={5}>
-                            rand:10-20,10-20
-                          </Text>
-                          <Text fontSize="xs" pr={5}>
-                            rand:10-20,10-20&base64:7nQBAAABAAAAAAAABnQtcmluZwZtc2VkZ2UDbmV0AAABAAE=,10-25
-                          </Text>
-                          <Text fontSize="xs" pr={5} pt="3">
-                            {t("hostsDialog.noise.info.attention")}
-                          </Text>
-                        </PopoverContent>
-                      </Portal>
-                    </Popover>
-                  }
-                  inputProps={{
-                    size: "sm",
-                    borderRadius: "4px",
-                  }}
-                />
-
-                <RHFCheckbox
-                  label={t("hostsDialog.useSniAsHost")}
-                  registerProps={register(
-                    `${hostKey}.${index}.use_sni_as_host`
-                  )}
-                  error={accordionErrors?.[index]?.use_sni_as_host}
-                />
-
-                <RHFCheckbox
-                  label={t("hostsDialog.allowinsecure")}
-                  registerProps={register(`${hostKey}.${index}.allowinsecure`)}
-                  error={accordionErrors?.[index]?.allowinsecure}
-                />
-
-                <RHFCheckbox
-                  label={t("hostsDialog.muxEnable")}
-                  registerProps={register(`${hostKey}.${index}.mux_enable`)}
-                  error={accordionErrors?.[index]?.mux_enable}
-                />
-
-                <RHFCheckbox
-                  label={t("hostsDialog.randomUserAgent")}
-                  registerProps={register(
-                    `${hostKey}.${index}.random_user_agent`
-                  )}
-                  error={accordionErrors?.[index]?.random_user_agent}
-                />
-
-                {bots.length > 0 && (
-                  <FormControl
-                    isInvalid={
-                      !!(
-                        accordionErrors && accordionErrors[index]?.bot_usernames
-                      )
-                    }
+            <HostAdvancedOptions
+              hostKey={hostKey}
+              index={index}
+              inbound={inbound}
+              register={register}
+              control={control}
+              accordionErrors={accordionErrors}
+              t={t}
+              bots={bots}
+              nodes={nodes}
+              proxyHostSecurity={proxyHostSecurity}
+              proxyALPN={proxyALPN}
+              proxyFingerprint={proxyFingerprint}
+            />
+          </AccordionItem> */}
+          <AccordionItem border="0">
+            {({ isExpanded }) => (
+              <>
+                <div style={{ display: "flex", alignItems: "center" }}>
+                  <AccordionButton
+                    display="flex"
+                    px={0}
+                    py={1}
+                    borderRadius={3}
+                    _hover={{ bg: "transparent" }}
                   >
-                    <FormLabel>{t("hostsDialog.availableBots")}</FormLabel>
                     <Text
+                      flex="3"
+                      align="start"
                       fontSize="xs"
                       color="gray.600"
-                      _dark={{ color: "gray.400" }}
-                      mb={2}
+                      _dark={{ color: "gray.500" }}
+                      pl={1}
                     >
-                      {t("hostsDialog.availableBots.info")}
+                      {t("hostsDialog.advancedOptions")}
+                      <AccordionIcon fontSize="sm" ml={1} />
                     </Text>
-                    <Controller
-                      control={control}
-                      name={`${hostKey}.${index}.bot_usernames`}
-                      render={({ field }) => {
-                        const selectedBotUsernames: string[] = Array.isArray(
-                          field.value
-                        )
-                          ? field.value
-                          : [];
-                        const selectedBots = bots.filter((bot: Bot) =>
-                          selectedBotUsernames.includes(bot.username)
-                        );
 
-                        return (
-                          <Popover placement="bottom-start">
-                            <PopoverTrigger>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                w="full"
-                                justifyContent="space-between"
-                              >
-                                <Text as="span" noOfLines={1}>
-                                  {selectedBots.length
-                                    ? t("hostsDialog.availableBots.selected", {
-                                        count: selectedBots.length,
-                                      })
-                                    : t("hostsDialog.availableBots.all")}
-                                </Text>
-                                <AccordionIcon />
-                              </Button>
-                            </PopoverTrigger>
-                            <Portal>
-                              <PopoverContent
-                                w="280px"
-                                maxH="320px"
-                                overflowY="auto"
-                                zIndex={1500}
-                              >
-                                <PopoverArrow />
-                                <PopoverCloseButton />
-                                <PopoverBody pt={8}>
-                                  <VStack align="start" spacing={2}>
-                                    {bots.map((bot: Bot) => (
-                                      <Checkbox
-                                        key={bot.username}
-                                        isChecked={selectedBotUsernames.includes(
-                                          bot.username
-                                        )}
-                                        onChange={(
-                                          event: ChangeEvent<HTMLInputElement>
-                                        ) => {
-                                          if (event.target.checked) {
-                                            field.onChange([
-                                              ...selectedBotUsernames,
-                                              bot.username,
-                                            ]);
-                                          } else {
-                                            field.onChange(
-                                              selectedBotUsernames.filter(
-                                                (username: string) =>
-                                                  username !== bot.username
-                                              )
-                                            );
-                                          }
-                                        }}
-                                      >
-                                        <Text as="span" fontSize="sm">
-                                          @{bot.username}
-                                          {bot.title ? ` (${bot.title})` : ""}
-                                        </Text>
-                                      </Checkbox>
-                                    ))}
-                                    {selectedBotUsernames.length > 0 && (
-                                      <Button
-                                        variant="ghost"
-                                        size="xs"
-                                        onClick={() => field.onChange([])}
-                                      >
-                                        {t("hostsDialog.availableBots.clear")}
-                                      </Button>
-                                    )}
-                                  </VStack>
-                                </PopoverBody>
-                              </PopoverContent>
-                            </Portal>
-                          </Popover>
-                        );
-                      }}
-                    />
-                    {accordionErrors &&
-                      accordionErrors[index]?.bot_usernames && (
-                        <Error>
-                          {accordionErrors[index]?.bot_usernames?.message}
-                        </Error>
-                      )}
-                  </FormControl>
-                )}
-                {nodes.filter((n) => n.id != null).length > 0 && (
-                  <FormControl>
-                    <FormLabel>{t("hostsDialog.linkedNodes")}</FormLabel>
-                    <Text
-                      fontSize="xs"
-                      color="gray.600"
-                      _dark={{ color: "gray.400" }}
-                      mb={2}
+                    <Container flex="1" px="0" display={"contents"}>
+                      <Controller
+                        control={control}
+                        name={`${hostKey}.${index}.is_disabled`}
+                        render={({ field }) => {
+                          return (
+                            <Switch
+                              mx="1.5"
+                              colorScheme="primary"
+                              isChecked={!!field.value}
+                              onChange={(e) => field.onChange(e.target.checked)}
+                            />
+                          );
+                        }}
+                      />
+                      <Tooltip label="Delete" placement="top">
+                        <IconButton
+                          aria-label="Delete"
+                          size="sm"
+                          colorScheme="red"
+                          variant="ghost"
+                          onClick={removeHost.bind(null, index)}
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </Container>
+                  </AccordionButton>
+                  <Tooltip label="Duplicate" placement="top">
+                    <IconButton
+                      aria-label="Duplicate"
+                      size="sm"
+                      colorScheme="white"
+                      variant="ghost"
+                      onClick={() => duplicateHost(index)}
                     >
-                      {t("hostsDialog.linkedNodes.info")}
-                    </Text>
-                    <Controller
-                      control={control}
-                      name={`${hostKey}.${index}.node_ids`}
-                      render={({ field }) => {
-                        const selectedIds: number[] = Array.isArray(field.value)
-                          ? field.value
-                          : [];
-                        return (
-                          <Popover isLazy placement="bottom-start">
-                            <PopoverTrigger>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                w="full"
-                                justifyContent="space-between"
-                              >
-                                <Text as="span" noOfLines={1}>
-                                  {selectedIds.length
-                                    ? t("hostsDialog.linkedNodes.selected", {
-                                        count: selectedIds.length,
-                                      })
-                                    : t("hostsDialog.linkedNodes.none")}
-                                </Text>
-                                <AccordionIcon />
-                              </Button>
-                            </PopoverTrigger>
-                            <Portal>
-                              <PopoverContent
-                                w="280px"
-                                maxH="320px"
-                                overflowY="auto"
-                                zIndex={1500}
-                              >
-                                <PopoverArrow />
-                                <PopoverCloseButton />
-                                <PopoverBody pt={8}>
-                                  <VStack align="start" spacing={2}>
-                                    {nodes
-                                      .filter((n) => n.id != null)
-                                      .map((node: NodeType) => {
-                                        const nodeId = node.id as number;
-                                        return (
-                                          <Checkbox
-                                            key={nodeId}
-                                            isChecked={selectedIds.includes(
-                                              nodeId
-                                            )}
-                                            onChange={(
-                                              event: ChangeEvent<HTMLInputElement>
-                                            ) => {
-                                              if (event.target.checked) {
-                                                field.onChange([
-                                                  ...selectedIds,
-                                                  nodeId,
-                                                ]);
-                                              } else {
-                                                field.onChange(
-                                                  selectedIds.filter(
-                                                    (id: number) =>
-                                                      id !== nodeId
-                                                  )
-                                                );
-                                              }
-                                            }}
-                                          >
-                                            <Text as="span" fontSize="sm">
-                                              {node.name}
-                                            </Text>
-                                          </Checkbox>
-                                        );
-                                      })}
-                                    {selectedIds.length > 0 && (
-                                      <Button
-                                        variant="ghost"
-                                        size="xs"
-                                        onClick={() => field.onChange([])}
-                                      >
-                                        {t("hostsDialog.linkedNodes.clear")}
-                                      </Button>
-                                    )}
-                                  </VStack>
-                                </PopoverBody>
-                              </PopoverContent>
-                            </Portal>
-                          </Popover>
-                        );
-                      }}
-                    />
-                  </FormControl>
+                      <DuplicateIcon />
+                    </IconButton>
+                  </Tooltip>
+                  {index < hostsLength - 1 && (
+                    <Tooltip label="Move Down" placement="top">
+                      <IconButton
+                        aria-label="DownIcon"
+                        size="sm"
+                        colorScheme="white"
+                        variant="ghost"
+                        onClick={() => moveHostPosition(index, "down")}
+                      >
+                        <DownIcon />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                  {index > 0 && (
+                    <Tooltip label="Move Up" placement="top">
+                      <IconButton
+                        aria-label="UpIcon"
+                        size="sm"
+                        colorScheme="white"
+                        variant="ghost"
+                        onClick={() => moveHostPosition(index, "up")}
+                      >
+                        <UpIcon />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </div>
+
+                {isExpanded && (
+                  <HostAdvancedOptions
+                    hostKey={hostKey}
+                    index={index}
+                    inbound={inbound}
+                    register={register}
+                    control={control}
+                    accordionErrors={accordionErrors}
+                    t={t}
+                    bots={bots}
+                    nodes={nodes}
+                    proxyHostSecurity={proxyHostSecurity}
+                    proxyALPN={proxyALPN}
+                    proxyFingerprint={proxyFingerprint}
+                  />
                 )}
-              </VStack>
-            </AccordionPanel>
+              </>
+            )}
           </AccordionItem>
         </Accordion>
       </VStack>

--- a/app/dashboard/src/components/hostsDialog/HostsInput.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostsInput.tsx
@@ -1,0 +1,195 @@
+import {
+  chakra,
+  Input as ChakraInput,
+  InputProps as ChakraInputProps,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  InputGroup,
+  InputLeftAddon,
+  InputRightAddon,
+  InputRightElement,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+} from "@chakra-ui/react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import classNames from "classnames";
+import React, { PropsWithChildren, ReactNode } from "react";
+
+const ClearIcon = chakra(XMarkIcon, {
+  baseStyle: {
+    w: 4,
+    h: 4,
+  },
+});
+
+export type HostsInputProps = PropsWithChildren<
+  {
+    value?: string;
+    className?: string;
+    endAdornment?: ReactNode;
+    startAdornment?: ReactNode;
+    type?: string;
+    placeholder?: string;
+    onChange?: (e: any) => void;
+    onBlur?: (e: any) => void;
+    onClick?: (e: any) => void;
+    name?: string;
+    error?: string;
+    disabled?: boolean;
+    step?: number;
+    label?: string;
+    clearable?: boolean;
+  } & ChakraInputProps
+>;
+
+export const HostsInput = React.forwardRef<HTMLInputElement, HostsInputProps>(
+  (
+    {
+      disabled,
+      step,
+      label,
+      className,
+      startAdornment,
+      endAdornment,
+      type = "text",
+      placeholder,
+      onChange,
+      onBlur,
+      name,
+      value,
+      onClick,
+      error,
+      clearable = false,
+      ...props
+    },
+    ref
+  ) => {
+    const clear = () => {
+      if (onChange)
+        onChange({
+          target: {
+            value: "",
+            name,
+          },
+        });
+    };
+    const { size = "md" } = props;
+    const Component = type == "number" ? NumberInputField : ChakraInput;
+    const Wrapper = type == "number" ? NumberInput : React.Fragment;
+    const wrapperProps =
+      type == "number"
+        ? {
+            keepWithinRange: true,
+            precision: 5,
+            format: (value: string | number) => {
+              return isNaN(parseFloat(String(value)))
+                ? value
+                : Number(parseFloat(String(value)).toFixed(5)) === 0
+                ? value
+                : Number(parseFloat(String(value)).toFixed(5));
+            },
+            min: 0,
+            step,
+            name,
+            type,
+            placeholder,
+            onChange: (valueAsString: string) => {
+              if (onChange) {
+                onChange({
+                  target: {
+                    value: valueAsString,
+                    name: name,
+                  },
+                });
+              }
+            },
+            onBlur,
+            value,
+            onClick,
+            disabled,
+            flexGrow: 1,
+            size,
+          }
+        : {};
+    return (
+      <FormControl isInvalid={!!error}>
+        {label && <FormLabel>{label}</FormLabel>}
+        <InputGroup
+          size={size}
+          w="full"
+          rounded="md"
+          _focusWithin={{
+            outline: "2px solid",
+            outlineColor: "primary.200",
+          }}
+          bg={disabled ? "gray.100" : "transparent"}
+          _dark={{ bg: disabled ? "gray.600" : "transparent" }}
+        >
+          {startAdornment && <InputLeftAddon>{startAdornment}</InputLeftAddon>}
+          <Wrapper {...wrapperProps}>
+            {/* @ts-ignore */}
+            <Component
+              name={name}
+              ref={ref}
+              step={step}
+              className={classNames(className)}
+              type={type}
+              placeholder={placeholder}
+              onChange={onChange}
+              onBlur={onBlur}
+              value={value}
+              onClick={onClick}
+              disabled={disabled}
+              flexGrow={1}
+              _focusVisible={{
+                outline: "none",
+                borderTopColor: "transparent",
+                borderRightColor: "transparent",
+                borderBottomColor: "transparent",
+              }}
+              _disabled={{
+                cursor: "not-allowed",
+              }}
+              {...props}
+              roundedLeft={startAdornment ? "0" : "md"}
+              roundedRight={endAdornment ? "0" : "md"}
+            />
+            {type == "number" && (
+              <>
+                <NumberInputStepper>
+                  <NumberIncrementStepper />
+                  <NumberDecrementStepper />
+                </NumberInputStepper>
+              </>
+            )}
+          </Wrapper>
+          {endAdornment && (
+            <InputRightAddon
+              borderLeftRadius={0}
+              borderRightRadius="6px"
+              bg="transparent"
+            >
+              {endAdornment}
+            </InputRightAddon>
+          )}
+          {clearable && value && value.length && (
+            <InputRightElement
+              borderLeftRadius={0}
+              borderRightRadius="6px"
+              bg="transparent"
+              onClick={clear}
+              cursor="pointer"
+            >
+              <ClearIcon />
+            </InputRightElement>
+          )}
+        </InputGroup>
+        {!!error && <FormErrorMessage>{error}</FormErrorMessage>}
+      </FormControl>
+    );
+  }
+);

--- a/app/dashboard/src/components/hostsDialog/RHFCheckbox.tsx
+++ b/app/dashboard/src/components/hostsDialog/RHFCheckbox.tsx
@@ -1,0 +1,9 @@
+import { Checkbox, FormControl, FormLabel } from "@chakra-ui/react";
+import { Error } from "./constants";
+
+export const RHFCheckbox = ({ label, registerProps, error }: any) => (
+  <FormControl isInvalid={!!error}>
+    <Checkbox {...registerProps}>{label}</Checkbox>
+    {error && <Error>{error.message}</Error>}
+  </FormControl>
+);

--- a/app/dashboard/src/components/hostsDialog/RHFField.tsx
+++ b/app/dashboard/src/components/hostsDialog/RHFField.tsx
@@ -1,0 +1,37 @@
+import { FormControl, FormLabel } from "@chakra-ui/react";
+import { Error } from "./constants";
+
+type RHFFieldProps = {
+  label: React.ReactNode;
+  error?: any;
+  isInvalid?: boolean;
+  rightElement?: React.ReactNode;
+  formControlProps?: any;
+  formLabelProps?: any;
+  children: React.ReactNode;
+};
+
+export const RHFField = ({
+  label,
+  error,
+  isInvalid,
+  rightElement,
+  formControlProps,
+  formLabelProps,
+  children,
+}: RHFFieldProps) => (
+  <FormControl isInvalid={isInvalid ?? !!error} {...formControlProps}>
+    <FormLabel
+      display="flex"
+      justifyContent="space-between"
+      {...formLabelProps}
+    >
+      <span>{label}</span>
+      {rightElement}
+    </FormLabel>
+
+    {children}
+
+    {error && <Error>{error.message}</Error>}
+  </FormControl>
+);

--- a/app/dashboard/src/components/hostsDialog/RHFInput.tsx
+++ b/app/dashboard/src/components/hostsDialog/RHFInput.tsx
@@ -1,0 +1,37 @@
+import { InputGroup } from "@chakra-ui/react";
+import { HostsInput } from "./HostsInput";
+import { RHFField } from "./RHFField";
+
+type RHFInputProps = {
+  label: React.ReactNode;
+  error?: any;
+  isInvalid?: boolean;
+  registerProps: any;
+  placeholder?: string;
+  type?: string;
+
+  rightElement?: React.ReactNode;
+
+  formControlProps?: any;
+  formLabelProps?: any;
+  inputProps?: any;
+};
+
+export const RHFInput = ({
+  registerProps,
+  placeholder,
+  type,
+  inputProps,
+  ...props
+}: RHFInputProps) => (
+  <RHFField {...props}>
+    <InputGroup>
+      <HostsInput
+        {...registerProps}
+        {...inputProps}
+        placeholder={placeholder}
+        type={type}
+      />
+    </InputGroup>
+  </RHFField>
+);

--- a/app/dashboard/src/components/hostsDialog/RHFSelect.tsx
+++ b/app/dashboard/src/components/hostsDialog/RHFSelect.tsx
@@ -1,0 +1,28 @@
+import { Select } from "./constants";
+import { RHFField } from "./RHFField";
+
+type RHFSelectProps = {
+  label: React.ReactNode;
+  error?: any;
+  registerProps: any;
+
+  children: React.ReactNode;
+
+  formControlProps?: any;
+  formLabelProps?: any;
+  selectProps?: any;
+  rightElement?: React.ReactNode;
+};
+
+export const RHFSelect = ({
+  registerProps,
+  children,
+  selectProps,
+  ...props
+}: RHFSelectProps) => (
+  <RHFField {...props}>
+    <Select {...registerProps} {...selectProps}>
+      {children}
+    </Select>
+  </RHFField>
+);

--- a/app/dashboard/src/components/hostsDialog/constants.tsx
+++ b/app/dashboard/src/components/hostsDialog/constants.tsx
@@ -1,0 +1,79 @@
+import {
+  Select as ChakraSelect,
+  FormErrorMessage,
+  chakra,
+} from "@chakra-ui/react";
+
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  DocumentDuplicateIcon,
+  LinkIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline";
+
+import { Input as CustomInput } from "../Input";
+
+export const DuplicateIcon = chakra(DocumentDuplicateIcon, {
+  baseStyle: {
+    w: 5,
+    h: 5,
+  },
+});
+
+export const UpIcon = chakra(ArrowUpIcon, {
+  baseStyle: {
+    w: 5,
+    h: 5,
+  },
+});
+
+export const DownIcon = chakra(ArrowDownIcon, {
+  baseStyle: {
+    w: 5,
+    h: 5,
+  },
+});
+
+export const Select = chakra(ChakraSelect, {
+  baseStyle: {
+    bg: "white",
+    _dark: {
+      bg: "gray.700",
+    },
+  },
+});
+
+export const Input = chakra(CustomInput, {
+  baseStyle: {
+    bg: "white",
+    _dark: {
+      bg: "gray.700",
+    },
+  },
+});
+
+export const InfoIcon = chakra(InformationCircleIcon, {
+  baseStyle: {
+    w: 4,
+    h: 4,
+    color: "gray.400",
+    cursor: "pointer",
+  },
+});
+
+export const Error = chakra(FormErrorMessage, {
+  baseStyle: {
+    color: "red.400",
+    display: "block",
+    textAlign: "left",
+    w: "100%",
+  },
+});
+
+export const ModalIcon = chakra(LinkIcon, {
+  baseStyle: {
+    w: 5,
+    h: 5,
+  },
+});

--- a/app/dashboard/src/components/hostsDialog/schema.tsx
+++ b/app/dashboard/src/components/hostsDialog/schema.tsx
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+export const hostsSchema = z.record(
+  z.string().min(1),
+  z.array(
+    z
+      .object({
+        remark: z.string().min(1, "Remark is required"),
+        address: z.string(),
+        port: z
+          .string()
+          .or(z.number())
+          .nullable()
+          .transform((value) => {
+            if (typeof value === "number") return value;
+            if (value !== null && !isNaN(parseInt(value)))
+              return Number(parseInt(value));
+            return null;
+          }),
+        path: z.string().nullable(),
+        sni: z.string().nullable(),
+        host: z.string().nullable(),
+        mux_enable: z.boolean().default(false),
+        allowinsecure: z.boolean().nullable().default(false),
+        is_disabled: z.boolean().default(true),
+        fragment_setting: z.string().nullable(),
+        noise_setting: z.string().nullable(),
+        random_user_agent: z.boolean().default(false),
+        security: z.string(),
+        alpn: z.string(),
+        fingerprint: z.string(),
+        use_sni_as_host: z.boolean().default(false),
+        bot_usernames: z.array(z.string()).default([]),
+        node_ids: z.array(z.number()).default([]),
+      })
+      .superRefine((data, ctx) => {
+        if (!data.address && (!data.node_ids || data.node_ids.length === 0)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["address"],
+            message: "Address or linked nodes required",
+          });
+        }
+      })
+  )
+);

--- a/scripts/perf-nodes/.gitignore
+++ b/scripts/perf-nodes/.gitignore
@@ -1,0 +1,1 @@
+created_node_ids.txt

--- a/scripts/perf-nodes/README.md
+++ b/scripts/perf-nodes/README.md
@@ -1,0 +1,44 @@
+# perf-nodes — нагрузочная проверка вкладки хостов (NPVPN-1585)
+
+Вспомогательные скрипты, чтобы наплодить много нод на стейдже и проверить,
+что вкладка хостов открывается быстро (после фикса ленивого рендера попапа нод).
+
+## Как пользоваться
+
+Задать базу API (без хардкода в скриптах — репозиторий публичный):
+
+```bash
+export BASE_URL='https://<panel-host>/api'
+```
+
+Получить Bearer-токен админа панели:
+
+```bash
+curl -X GET "$BASE_URL/admin" \
+  -H 'accept: application/json' \
+  -H 'Authorization: Bearer <token>'
+```
+
+Создать 200 нод (id пишутся в `created_node_ids.txt`):
+
+```bash
+TOKEN="<bearer>" ./create_nodes.sh 200
+```
+
+Удалить всё созданное (читает `created_node_ids.txt`):
+
+```bash
+TOKEN="<bearer>" ./delete_nodes.sh
+```
+
+## Детали
+
+- Ноды создаются с `add_as_new_host=false` — хосты не плодятся, только ноды.
+- Адреса фейковые (`240.0.0.x`), ноды повиснут в `connecting`/`error` —
+  для проверки рендера списка нод это неважно.
+- `delete_nodes.sh` вычёркивает удалённые id из файла, поэтому его можно
+  перезапускать — останутся только неудалённые.
+
+Переменные окружения (обе команды): `BASE_URL` (default `https://rutest.npvpn.net/api`),
+`IDS_FILE` (default `created_node_ids.txt`). Для `create_nodes.sh` дополнительно:
+`PREFIX`, `RUN`, `COUNT`.

--- a/scripts/perf-nodes/create_nodes.sh
+++ b/scripts/perf-nodes/create_nodes.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# NPVPN-1585 — создание фейковых нод для нагрузочной проверки вкладки хостов.
+#
+# Создаёт COUNT нод через POST /api/node и пишет их id в IDS_FILE,
+# чтобы потом удалить скриптом delete_nodes.sh.
+#
+# Ноды создаются с add_as_new_host=false — хосты НЕ плодятся, только ноды.
+# Адреса фейковые (240.0.0.x), ноды повиснут в статусе connecting/error —
+# для проверки рендера списка нод это неважно.
+#
+# Использование:
+#   TOKEN="<bearer>" ./create_nodes.sh [COUNT]
+#
+# Переменные окружения:
+#   TOKEN     — Bearer-токен админа (ОБЯЗАТЕЛЬНО). Получить:
+#                 curl -X GET '<BASE_URL>/admin' \
+#                   -H 'Authorization: Bearer <token>'
+#   BASE_URL  — база API, напр. https://<panel-host>/api (ОБЯЗАТЕЛЬНО)
+#   PREFIX    — префикс имени ноды (default: perftest-1585)
+#   RUN       — метка прогона в имени (default: текущее время)
+#   IDS_FILE  — файл со списком созданных id (default: created_node_ids.txt)
+#   COUNT     — сколько нод создать (можно 1-м аргументом, default: 200)
+#
+set -uo pipefail
+
+: "${TOKEN:?Задай TOKEN='<bearer>' — токен админа панели}"
+: "${BASE_URL:?Задай BASE_URL='https://<panel-host>/api'}"
+PREFIX="${PREFIX:-perftest-1585}"
+RUN="${RUN:-$(date +%Y%m%d-%H%M%S)}"
+IDS_FILE="${IDS_FILE:-created_node_ids.txt}"
+COUNT="${1:-${COUNT:-200}}"
+
+command -v jq >/dev/null 2>&1 || { echo "Нужен jq"; exit 1; }
+
+echo "Создаю $COUNT нод на $BASE_URL (префикс: ${PREFIX}-${RUN})"
+echo "id пишу в: $IDS_FILE"
+: > "$IDS_FILE"
+
+created=0
+failed=0
+for i in $(seq 1 "$COUNT"); do
+  name="${PREFIX}-${RUN}-$(printf '%03d' "$i")"
+  addr="240.0.$(( (i >> 8) & 255 )).$(( i & 255 ))"
+
+  resp=$(curl -sS -w $'\n%{http_code}' -X POST "${BASE_URL}/node" \
+    -H "accept: application/json" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\":\"${name}\",\"address\":\"${addr}\",\"port\":62050,\"api_port\":62051,\"protocol\":\"rest\",\"usage_coefficient\":1,\"add_as_new_host\":false}")
+
+  code=$(printf '%s' "$resp" | tail -n1)
+  body=$(printf '%s' "$resp" | sed '$d')
+
+  if [ "$code" = "200" ] || [ "$code" = "201" ]; then
+    id=$(printf '%s' "$body" | jq -r '.id // empty')
+    if [ -n "$id" ]; then
+      echo "$id" >> "$IDS_FILE"
+      created=$((created + 1))
+    else
+      echo "  [$i] 200, но нет id в ответе: $body"
+      failed=$((failed + 1))
+    fi
+  else
+    echo "  [$i] ошибка HTTP $code: $(printf '%s' "$body" | head -c 200)"
+    failed=$((failed + 1))
+  fi
+
+  if [ $((i % 25)) -eq 0 ]; then
+    echo "  ...прогресс: $i/$COUNT (создано $created, ошибок $failed)"
+  fi
+done
+
+echo "Готово. Создано: $created, ошибок: $failed. id в $IDS_FILE"

--- a/scripts/perf-nodes/delete_nodes.sh
+++ b/scripts/perf-nodes/delete_nodes.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# NPVPN-1585 — удаление нод, созданных create_nodes.sh.
+#
+# Читает id из IDS_FILE (по одному в строке) и удаляет каждую ноду
+# через DELETE /api/node/{id}. Успешно удалённые id вычёркиваются из файла,
+# так что скрипт можно перезапускать — останутся только неудалённые.
+#
+# Использование:
+#   TOKEN="<bearer>" ./delete_nodes.sh
+#
+# Переменные окружения:
+#   TOKEN     — Bearer-токен админа (ОБЯЗАТЕЛЬНО)
+#   BASE_URL  — база API, напр. https://<panel-host>/api (ОБЯЗАТЕЛЬНО)
+#   IDS_FILE  — файл со списком id (default: created_node_ids.txt)
+#
+set -uo pipefail
+
+: "${TOKEN:?Задай TOKEN='<bearer>' — токен админа панели}"
+: "${BASE_URL:?Задай BASE_URL='https://<panel-host>/api'}"
+IDS_FILE="${IDS_FILE:-created_node_ids.txt}"
+
+[ -f "$IDS_FILE" ] || { echo "Нет файла $IDS_FILE"; exit 1; }
+
+total=$(grep -c '[0-9]' "$IDS_FILE" || true)
+echo "Удаляю $total нод с $BASE_URL (из $IDS_FILE)"
+
+remaining_file="$(mktemp)"
+deleted=0
+failed=0
+i=0
+while IFS= read -r id; do
+  [ -n "$id" ] || continue
+  i=$((i + 1))
+
+  code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE "${BASE_URL}/node/${id}" \
+    -H "accept: application/json" \
+    -H "Authorization: Bearer ${TOKEN}")
+
+  # 200 — удалили, 404 — ноды уже нет (считаем успехом)
+  if [ "$code" = "200" ] || [ "$code" = "204" ] || [ "$code" = "404" ]; then
+    deleted=$((deleted + 1))
+  else
+    echo "  [id=$id] ошибка HTTP $code — оставляю в файле"
+    echo "$id" >> "$remaining_file"
+    failed=$((failed + 1))
+  fi
+
+  if [ $((i % 25)) -eq 0 ]; then
+    echo "  ...прогресс: $i/$total (удалено $deleted, ошибок $failed)"
+  fi
+done < "$IDS_FILE"
+
+mv "$remaining_file" "$IDS_FILE"
+echo "Готово. Удалено: $deleted, ошибок: $failed. Остаток id в $IDS_FILE"


### PR DESCRIPTION
## Проблема

На сервере с 200+ нодами вкладка хостов не открывается — браузер подвисает.

Причина — регрессия из NPVPN-1512. Добавленный там попап выбора нод (`node_ids`) в `HostsDialog` рендерится **без `isLazy`**, в отличие от остальных 9 попапов файла. Chakra монтирует все чекбоксы нод в DOM сразу для каждого хоста ещё до открытия попапа. При `(число хостов) × 200` чекбоксов вкладка вешает браузер.

Сетевого дублирования нет — `/nodes` фетчится один раз. Проблема чисто в рендере DOM.

## Решение

Добавлен `isLazy` попапу выбора нод (`HostsDialog.tsx`) — ровно как у остальных попапов в этом файле. Чекбоксы нод монтируются только при открытии конкретного попапа и размонтируются при закрытии (`lazyBehavior="unmount"` по умолчанию у Chakra). До открытия — ноль node-чекбоксов в DOM.

## Проверка

- [ ] Собрать образ панели, открыть вкладку хостов на стейдже с 200+ нодами — открывается мгновенно
- [ ] Попап выбора нод по клику показывает список и сохраняет выбор

Логика выбора (`node_ids`, `Controller`, валидатор address/node_ids) не менялась — только момент монтирования DOM.
