### PR TITLE
NPVPN-1581/add other logic for page

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -756,10 +756,20 @@ def count_user_devices(db: Session, dbuser: User) -> int:
     )
 
 
-def is_device_limit_exceeded(db: Session, dbuser: User) -> bool:
-    if not dbuser.device_limit:
+def is_device_limit_reached(db: Session, dbuser: User) -> bool:
+    """True when active devices are at or over the limit (e.g. 10/10, 11/10)."""
+    limit = dbuser.device_limit
+    if not limit:
         return False
-    return count_user_devices(db, dbuser) >= dbuser.device_limit
+    return count_user_devices(db, dbuser) >= int(limit)
+
+
+def is_device_limit_exceeded(db: Session, dbuser: User) -> bool:
+    """True when active devices strictly exceed the limit (e.g. 11/10, not 10/10)."""
+    limit = dbuser.device_limit
+    if not limit:
+        return False
+    return count_user_devices(db, dbuser) > int(limit)
 
 
 def create_user_device(db: Session, dbuser: User, device: UserDeviceCreate) -> UserDevice:

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -242,7 +242,7 @@ def user_subscription(
     user: UserResponse = UserResponse.model_validate(dbuser)
     bot_settings = resolve_bot_settings(dbuser)
 
-    is_limited = not is_revoked and not is_expired and crud.is_device_limit_exceeded(db, dbuser)
+    is_limited = not is_revoked and not is_expired and crud.is_device_limit_reached(db, dbuser)
 
     accept_header = request.headers.get("Accept", "")
     if "text/html" in accept_header:

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -391,7 +391,6 @@ app/db/crud.py:0: error: Incompatible types in assignment (expression has type "
 app/db/crud.py:0: error: Incompatible types in assignment (expression has type "datetime", variable has type "Column[datetime]")  [assignment]
 app/db/crud.py:0: error: Incompatible types in assignment (expression has type "int", variable has type "Column[int]")  [assignment]
 app/db/crud.py:0: error: Incompatible types in assignment (expression has type "datetime", variable has type "Column[datetime]")  [assignment]
-app/db/crud.py:0: error: Incompatible return value type (got "ColumnElement[bool]", expected "bool")  [return-value]
 app/db/crud.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "Column[str]")  [assignment]
 app/db/crud.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "Column[str]")  [assignment]
 app/db/crud.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "Column[str]")  [assignment]


### PR DESCRIPTION
## Что и зачем
При лимите устройств заглушки в подписке клиента и веб-страница `limited.html` должны срабатывать по разным правилам. Раньше одна проверка `count >= limit` включала серверы-заглушки уже при 10/10 — это мешало пользователям, у которых устройства были добавлены до включения лимита. Нужно: в клиенте заглушки только при превышении (11/10), а в браузере страница лимита — уже при достижении (10/10).

## Изменения
- Добавлена `is_device_limit_reached` (`count >= limit`) — выбор `limited.html` вместо `index.html`
- `is_device_limit_exceeded` переведена на строгое превышение (`count > limit`) — серверы-заглушки в v2ray/v2ray-json подписке
- Блокировка регистрации нового устройства (`register_user_device`, `>=`) и полная заглушка при попытке добавить 11-е устройство — без изменений
- Обновлён `mypy-baseline.txt` (убрана ошибка типов после `int(limit)`)

## Заметки для ревью
- Проверить сценарии: 10/10 (существующее устройство) — обычная подписка + `limited.html` в браузере; 11/10 (устройства до лимита) — заглушки в подписке + `limited.html`; попытка 11-го устройства после включения лимита — полная заглушка
- Env / миграции не требуются