### PR TITLE
NPVPN-1579/change to post req for revoke

### DIFF
--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -405,6 +405,7 @@ def user_subscription(
 @router.get("/{token}/devices/{device_id}/revoke", include_in_schema=False)
 @router.post("/{token}/devices/{device_id}/revoke", include_in_schema=False)
 def revoke_subscription_device(
+    request: Request,
     token: str,
     device_id: int,
     db: Session = Depends(get_db),
@@ -422,6 +423,8 @@ def revoke_subscription_device(
         raise HTTPException(status_code=404, detail="Active device not found")
 
     crud.revoke_user_device(db, dbdevice)
+    if request.method == "POST":
+        return Response(status_code=204)
     return RedirectResponse(url=f"/{XRAY_SUBSCRIPTION_PATH}/{token}", status_code=303)
 
 

--- a/templates/sub/limited.html
+++ b/templates/sub/limited.html
@@ -77,7 +77,8 @@
 
             try {
               const response = await fetch(
-                `/{{ sub_path }}/{{ token }}/devices/${deviceId}/revoke`
+                `/{{ sub_path }}/{{ token }}/devices/${deviceId}/revoke`,
+                { method: 'POST' }
               );
 
               if (!response.ok) {
@@ -92,7 +93,7 @@
                 this.deviceLimit > 0 &&
                 this.devices.length <= this.deviceLimit
               ) {
-                window.location.href = this.subUrl;
+                window.location.reload();
               }
             } catch {
               alert('Не удалось удалить устройство. Попробуйте ещё раз.');


### PR DESCRIPTION
## Что и зачем
После удаления последнего устройства на `limited.html` в базе появлялось «неизвестное» устройство с Mozilla UA, а revoke через `fetch` мог падать с ошибкой. Причина — `GET` + `303`: `fetch` автоматически шёл на `/sub` с `Accept: */*`, и запрос регистрировался как клиент без hwid.

## Изменения
- `limited.html`: revoke через `POST`, локальное удаление из списка, `reload()` только когда лимит больше не превышен (переход на `index.html`)
- `subscription.py`: для `POST` revoke — `204` без редиректа; для `GET` — `303` (прямая ссылка в браузере)

## Заметки для ревью
- Сопутствующий PR в `telegram_bot`: nginx должен пропускать `POST` на `/sub/` (иначе `405 Method Not Allowed`)
- Регрессия появилась после отката фикса из `7abf3f4` в коммите `c8aeeb9` (возврат к `GET` + `303` в `fetch`)