### PR TITLE
NPVPN-1526/fix if for _ in <tg_id>

### DIFF
--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -68,8 +68,7 @@ def get_user_note(user: UserResponse, note_template: str) -> str:
     """Return note from SUB_CLIENT_NOTE with <days_left> and <tg_id> placeholders."""
     if not note_template:
         return ""
-    if "_" in user.username:
-        note_template = note_template.replace("<tg_id>", user.username.split("_", 1)[0])
+    note_template = note_template.replace("<tg_id>", user.username.split("_", 1)[0])
     expire_ts = int(user.expire or 0)
     if expire_ts <= 0:
         return note_template.replace("<days_left>", "0")


### PR DESCRIPTION
## Что и зачем
В тексте анонса подписки (`SUB_CLIENT_NOTE` и связанные шаблоны) плейсхолдер `<tg_id>` подставлялся только если в `username` есть `_`. Без черты в анонсе оставался сырой `<tg_id>`. Теперь подстановка выполняется всегда: при `_` — часть до первой черты, иначе — весь `username`.

## Изменения
- `get_user_note`: убрано условие `if "_" in user.username`, подмена `<tg_id>` через `user.username.split("_", 1)[0]` для любого формата username

## Заметки для ревью
- Затрагивает только panel, логика `<days_left>` без изменений
- Ручных шагов и миграций нет