### PR TITLE
NPVPN-1557/add in locales id of version

### DIFF
--- a/app/dashboard/src/locales/i18n.ts
+++ b/app/dashboard/src/locales/i18n.ts
@@ -10,6 +10,8 @@ import HttpApi from "i18next-http-backend";
 import { registerLocale } from "react-datepicker";
 import { initReactI18next } from "react-i18next";
 
+declare const __I18N_VERSION__: string;
+
 declare module "i18next" {
     interface CustomTypeOptions {
         returnNull: false;
@@ -36,10 +38,11 @@ i18n
                 caches: ["localStorage", "sessionStorage", "cookie"],
             },
             backend: {
-                loadPath: joinPaths([
-                    import.meta.env.BASE_URL,
-                    `statics/locales/{{lng}}.json`,
-                ]),
+                loadPath:
+                    joinPaths([
+                        import.meta.env.BASE_URL,
+                        `statics/locales/{{lng}}.json`,
+                    ]) + `?v=${__I18N_VERSION__}`,
             },
         },
         function (err, t) {

--- a/app/dashboard/vite.config.ts
+++ b/app/dashboard/vite.config.ts
@@ -4,8 +4,13 @@ import svgr from "vite-plugin-svgr";
 import { visualizer } from "rollup-plugin-visualizer";
 import tsconfigPaths from "vite-tsconfig-paths";
 
+const i18nVersion = process.env.VITE_BUILD_ID || Date.now().toString();
+
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    __I18N_VERSION__: JSON.stringify(i18nVersion),
+  },
   plugins: [
     tsconfigPaths(),
     react({


### PR DESCRIPTION
## Что и зачем
После деплоя панели при изменениях в дашборде в интерфейсе вместо текстов показывались ключи i18n (например, `userDialog.subRoutingHapp`). JS-бандл обновлялся (хеш в имени), а `statics/locales/*.json` — нет: браузер отдавал старый JSON из кэша без новых ключей. Hard reload помогал.

Добавлен cache-busting: при каждой сборке в URL локалей подставляется версия (`?v=...`), поэтому после деплоя браузер запрашивает актуальные файлы.

## Изменения
- `vite.config.ts` — при сборке задаётся `__I18N_VERSION__` (`VITE_BUILD_ID` или timestamp)
- `i18n.ts` — `loadPath` для локалей: `statics/locales/{{lng}}.json?v=<версия>`

## Заметки для ревью
- Правки nginx не нужны: достаточно смены URL при новой сборке
- В рамках одного деплоя локали по-прежнему могут кэшироваться браузером (это ок — содержимое не меняется)
- Для проверки: задеплоить, открыть дашборд без hard reload — новые ключи должны отображаться текстом