### PR TITLE
NPVPN-1596: балансировка хостов по нескольким нодам через xray-балансировщик

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,13 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-check
-        name: ruff-strict (staged)
+        name: ruff-strict (manual)
         alias: ruff-strict
         args: [--config, ruff-strict.toml]
+        # Неблокирующий: в CI strict — informational (continue-on-error), только по
+        # изменённым файлам. Здесь тоже не блокируем коммит — запуск вручную:
+        # pre-commit run ruff-strict --hook-stage manual (или uv run ruff check --config ruff-strict.toml).
+        stages: [manual]
       - id: ruff-format
 
   - repo: local

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -504,8 +504,7 @@ def process_inbounds_and_tags(
                     add_kwargs["is_bs"] = True
                 if balanced:
                     addresses = [
-                        addr.replace("*", secrets.token_hex(8)).format_map(format_variables)
-                        for addr in address_list
+                        addr.replace("*", secrets.token_hex(8)).format_map(format_variables) for addr in address_list
                     ]
                     conf.add_balanced(
                         remark=host["remark"].format_map(format_variables),

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -455,7 +455,8 @@ def process_inbounds_and_tags(
 
                 address = ""
                 address_list = host["address"]
-                if host["address"]:
+                balanced = isinstance(conf, V2rayJsonConfig) and address_list and len(address_list) > 1
+                if address_list and not balanced:
                     salt = secrets.token_hex(8)
                     address = random.choice(address_list).replace("*", salt)
 
@@ -501,13 +502,26 @@ def process_inbounds_and_tags(
                 add_kwargs = {}
                 if isinstance(conf, V2rayJsonConfig) and host_matches_blocked(host["address"], bs_addresses):
                     add_kwargs["is_bs"] = True
-                conf.add(
-                    remark=host["remark"].format_map(format_variables),
-                    address=address.format_map(format_variables),
-                    inbound=host_inbound,
-                    settings=settings.model_dump(),
-                    **add_kwargs,
-                )
+                if balanced:
+                    addresses = [
+                        addr.replace("*", secrets.token_hex(8)).format_map(format_variables)
+                        for addr in address_list
+                    ]
+                    conf.add_balanced(
+                        remark=host["remark"].format_map(format_variables),
+                        addresses=addresses,
+                        inbound=host_inbound,
+                        settings=settings.model_dump(),
+                        **add_kwargs,
+                    )
+                else:
+                    conf.add(
+                        remark=host["remark"].format_map(format_variables),
+                        address=address.format_map(format_variables),
+                        inbound=host_inbound,
+                        settings=settings.model_dump(),
+                        **add_kwargs,
+                    )
 
     return conf.render(reverse=reverse)
 

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -502,7 +502,7 @@ def process_inbounds_and_tags(
                 add_kwargs = {}
                 if isinstance(conf, V2rayJsonConfig) and host_matches_blocked(host["address"], bs_addresses):
                     add_kwargs["is_bs"] = True
-                if balanced:
+                if balanced and isinstance(conf, V2rayJsonConfig):
                     addresses = [
                         addr.replace("*", secrets.token_hex(8)).format_map(format_variables) for addr in address_list
                     ]

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -12,6 +12,7 @@ from app.subscription.funcs import get_grpc_gun, get_grpc_multi
 from app.templates import render_template
 from app.utils.helpers import UUIDEncoder
 from app.xray.bs_routing import select_routing
+from app.xray.host_balancer import apply_host_balancer, proxy_outbound_tag
 from config import (
     EXTERNAL_CONFIG,
     GRPC_USER_AGENT_TEMPLATE,
@@ -502,7 +503,7 @@ class V2rayJsonConfig(str):
 
         del user_agent_data, grpc_user_agent_data
 
-    def add_config(self, remarks, outbounds, is_bs=False):
+    def _assemble_config(self, remarks, outbounds, is_bs=False):
         json_template = json.loads(self.template)
         json_template["remarks"] = remarks
         json_template["outbounds"] = outbounds + json_template["outbounds"]
@@ -512,7 +513,23 @@ class V2rayJsonConfig(str):
             self.routing_bs,
             is_bs,
         )
-        self.config.append(json_template)
+        return json_template
+
+    def add_config(self, remarks, outbounds, is_bs=False):
+        self.config.append(self._assemble_config(remarks, outbounds, is_bs))
+
+    def add_balanced(self, remark: str, addresses: list, inbound: dict, settings: dict, is_bs: bool = False):
+        """Multi-address хост → один конфиг с N proxy-outbound + xray-балансировщик."""
+        dialer = self.make_dialer_outbound(inbound["fragment_setting"], inbound["noise_setting"])
+        dialer_proxy = dialer["tag"] if dialer else ""
+        outbounds = [
+            self._build_proxy_outbound(proxy_outbound_tag(i), address, inbound, settings, dialer_proxy)
+            for i, address in enumerate(addresses)
+        ]
+        if dialer:
+            outbounds.append(dialer)
+        config = self._assemble_config(remark, outbounds, is_bs)
+        self.config.append(apply_host_balancer(config))
 
     def render(self, reverse=False):
         if reverse:
@@ -960,8 +977,7 @@ class V2rayJsonConfig(str):
             network=net, security=tls, network_setting=network_setting, tls_settings=tls_settings, sockopt=sockopt
         )
 
-    def add(self, remark: str, address: str, inbound: dict, settings: dict, is_bs: bool = False):
-
+    def _build_proxy_outbound(self, tag, address, inbound, settings, dialer_proxy=""):
         net = inbound["network"]
         protocol = inbound["protocol"]
         port = inbound["port"]
@@ -971,8 +987,6 @@ class V2rayJsonConfig(str):
 
         tls = inbound["tls"]
         headers = inbound["header_type"]
-        fragment = inbound["fragment_setting"]
-        noise = inbound["noise_setting"]
         path = inbound["path"]
         multi_mode = inbound.get("multiMode", False)
 
@@ -982,33 +996,22 @@ class V2rayJsonConfig(str):
             else:
                 path = get_grpc_gun(path)
 
-        outbound = {"tag": "proxy", "protocol": protocol}
+        outbound = {"tag": tag, "protocol": protocol}
 
-        if inbound["protocol"] == "vmess":
+        if protocol == "vmess":
             outbound["settings"] = self.vmess_config(address=address, port=port, id=settings["id"])
-
-        elif inbound["protocol"] == "vless":
+        elif protocol == "vless":
             if net in ("tcp", "raw", "kcp") and headers != "http" and tls in ("tls", "reality"):
                 flow = settings.get("flow", "")
             else:
                 flow = None
-
             outbound["settings"] = self.vless_config(address=address, port=port, id=settings["id"], flow=flow)
-
-        elif inbound["protocol"] == "trojan":
+        elif protocol == "trojan":
             outbound["settings"] = self.trojan_config(address=address, port=port, password=settings["password"])
-
-        elif inbound["protocol"] == "shadowsocks":
+        elif protocol == "shadowsocks":
             outbound["settings"] = self.shadowsocks_config(
                 address=address, port=port, password=settings["password"], method=settings["method"]
             )
-
-        outbounds = [outbound]
-        dialer_proxy = ""
-        extra_outbound = self.make_dialer_outbound(fragment, noise)
-        if extra_outbound:
-            dialer_proxy = extra_outbound["tag"]
-            outbounds.append(extra_outbound)
 
         alpn = inbound.get("alpn", None)
         outbound["streamSettings"] = self.make_stream_setting(
@@ -1038,11 +1041,18 @@ class V2rayJsonConfig(str):
             keepAlivePeriod=inbound.get("keepAlivePeriod", 0),
         )
 
-        mux_json = json.loads(self.mux_template)
-        mux_config = mux_json["v2ray"]
-
         if inbound.get("mux_enable", False):
+            mux_config = json.loads(self.mux_template)["v2ray"]
+            mux_config["enabled"] = True
             outbound["mux"] = mux_config
-            outbound["mux"]["enabled"] = True
 
+        return outbound
+
+    def add(self, remark: str, address: str, inbound: dict, settings: dict, is_bs: bool = False):
+        dialer = self.make_dialer_outbound(inbound["fragment_setting"], inbound["noise_setting"])
+        dialer_proxy = dialer["tag"] if dialer else ""
+        outbound = self._build_proxy_outbound("proxy", address, inbound, settings, dialer_proxy)
+        outbounds = [outbound]
+        if dialer:
+            outbounds.append(dialer)
         self.add_config(remarks=remark, outbounds=outbounds, is_bs=is_bs)

--- a/app/xray/host_balancer.py
+++ b/app/xray/host_balancer.py
@@ -1,0 +1,68 @@
+"""Чистая генерация xray-балансировщика для multi-address хостов подписки (NPVPN-1596).
+
+Хост, связанный с несколькими нодами (или со статическим address через запятую),
+в формате v2ray-json отдаётся одним конфигом с N proxy-outbound (теги proxy, proxy-1, …)
+и балансировщиком strategy=random. Мёртвые ноды отсеиваются observatory: RandomStrategy
+в xray-core фильтрует кандидатов по observation, если observatory присутствует.
+
+Без импортов БД/шаблонов — покрывается pytest без окружения (как cascade_config/bs_routing).
+"""
+
+from __future__ import annotations
+
+PROXY_OUTBOUND_TAG = "proxy"
+HOST_BALANCER_TAG = "proxy-balancer"
+HOST_BALANCER_STRATEGY = "random"
+
+OBSERVATORY_PROBE_URL = "https://www.google.com/generate_204"
+OBSERVATORY_INTERVAL = "1m"
+
+
+def proxy_outbound_tag(index: int) -> str:
+    """Тег proxy-outbound: первый — 'proxy' (обратная совместимость с явным
+    outboundTag:'proxy' в пользовательском routing), остальные — 'proxy-<i>'."""
+    return PROXY_OUTBOUND_TAG if index == 0 else f"{PROXY_OUTBOUND_TAG}-{index}"
+
+
+def build_balancer() -> dict:
+    """Балансировщик по всем proxy-outbound (селектор по префиксу тега)."""
+    return {
+        "tag": HOST_BALANCER_TAG,
+        "selector": [PROXY_OUTBOUND_TAG],
+        "strategy": {"type": HOST_BALANCER_STRATEGY},
+    }
+
+
+def build_balancer_rule() -> dict:
+    """Catch-all: весь оставшийся tcp/udp-трафик → балансировщик.
+
+    Ставится ПОСЛЕДНИМ в rules — xray матчит сверху вниз, first-match-wins, так что
+    правила block/direct должны отработать раньше. Раньше этот трафик уходил в первый
+    outbound (proxy) как дефолт xray; теперь его перехватывает balancerTag."""
+    return {
+        "type": "field",
+        "network": "tcp,udp",
+        "balancerTag": HOST_BALANCER_TAG,
+    }
+
+
+def build_observatory() -> dict:
+    """Health-check proxy-outbound'ов: по нему random отсеивает мёртвые ноды."""
+    return {
+        "subjectSelector": [PROXY_OUTBOUND_TAG],
+        "probeUrl": OBSERVATORY_PROBE_URL,
+        "probeInterval": OBSERVATORY_INTERVAL,
+    }
+
+
+def apply_host_balancer(config: dict) -> dict:
+    """Дописать в собранный v2ray-json конфиг балансировщик, catch-all rule и observatory.
+
+    Вызывается только когда proxy-outbound'ов >1 (см. V2rayJsonConfig.add_balanced).
+    Мутирует и возвращает config.
+    """
+    routing = config.setdefault("routing", {})
+    routing["balancers"] = routing.get("balancers", []) + [build_balancer()]
+    routing["rules"] = routing.get("rules", []) + [build_balancer_rule()]
+    config["observatory"] = build_observatory()
+    return config

--- a/app/xray/host_balancer.py
+++ b/app/xray/host_balancer.py
@@ -2,8 +2,15 @@
 
 Хост, связанный с несколькими нодами (или со статическим address через запятую),
 в формате v2ray-json отдаётся одним конфигом с N proxy-outbound (теги proxy, proxy-1, …)
-и балансировщиком strategy=random. Мёртвые ноды отсеиваются observatory: RandomStrategy
-в xray-core фильтрует кандидатов по observation, если observatory присутствует.
+и балансировщиком strategy=random — клиент (xray-ядро) раскидывает соединения по всем
+нодам. Это ровно рабочий путь каскада (app/xray/cascade_config.py), где random-балансировщик
+идёт БЕЗ observatory.
+
+observatory (health-check) сознательно НЕ добавляем: на живом клиенте (Happ/xray 26.x) связка
+random+observatory роняет весь проксируемый трафик — RandomStrategy фильтрует пул по observation,
+а пробы (google/generate_204 через ноды из РФ) не проходят → «живых» нод нет → балансировщик
+не выбирает ни один outbound. Отсев мёртвых нод, если понадобится, делаем серверно (как для
+БС-нод через review-джоб), а не клиентским observatory.
 
 Без импортов БД/шаблонов — покрывается pytest без окружения (как cascade_config/bs_routing).
 """
@@ -13,9 +20,6 @@ from __future__ import annotations
 PROXY_OUTBOUND_TAG = "proxy"
 HOST_BALANCER_TAG = "proxy-balancer"
 HOST_BALANCER_STRATEGY = "random"
-
-OBSERVATORY_PROBE_URL = "https://www.google.com/generate_204"
-OBSERVATORY_INTERVAL = "1m"
 
 
 def proxy_outbound_tag(index: int) -> str:
@@ -46,19 +50,11 @@ def build_balancer_rule() -> dict:
     }
 
 
-def build_observatory() -> dict:
-    """Health-check proxy-outbound'ов: по нему random отсеивает мёртвые ноды."""
-    return {
-        "subjectSelector": [PROXY_OUTBOUND_TAG],
-        "probeUrl": OBSERVATORY_PROBE_URL,
-        "probeInterval": OBSERVATORY_INTERVAL,
-    }
-
-
 def apply_host_balancer(config: dict) -> dict:
-    """Дописать в собранный v2ray-json конфиг балансировщик, catch-all rule и observatory.
+    """Дописать в собранный v2ray-json конфиг балансировщик и catch-all rule.
 
     Вызывается только когда proxy-outbound'ов >1 (см. V2rayJsonConfig.add_balanced).
+    observatory НЕ добавляем (см. модульный docstring — ломает трафик на клиенте).
 
     ВАЖНО: не мутирует config["routing"] на месте — select_routing()
     (app/xray/bs_routing.py) может отдавать ОДИН И ТОТ ЖЕ routing-объект (без копии)
@@ -73,5 +69,4 @@ def apply_host_balancer(config: dict) -> dict:
     routing["balancers"] = list(routing.get("balancers", [])) + [build_balancer()]
     routing["rules"] = list(routing.get("rules", [])) + [build_balancer_rule()]
     config["routing"] = routing
-    config["observatory"] = build_observatory()
     return config

--- a/app/xray/host_balancer.py
+++ b/app/xray/host_balancer.py
@@ -59,10 +59,19 @@ def apply_host_balancer(config: dict) -> dict:
     """Дописать в собранный v2ray-json конфиг балансировщик, catch-all rule и observatory.
 
     Вызывается только когда proxy-outbound'ов >1 (см. V2rayJsonConfig.add_balanced).
-    Мутирует и возвращает config.
+
+    ВАЖНО: не мутирует config["routing"] на месте — select_routing()
+    (app/xray/bs_routing.py) может отдавать ОДИН И ТОТ ЖЕ routing-объект (без копии)
+    во все серверные конфиги подписки (_assemble_config в app/subscription/v2ray.py).
+    Мутация на месте протекла бы между конфигами: одноадресные хосты получали бы
+    чужой balancer, а при 2+ multi-address хостах — по несколько одинаковых
+    балансировщиков с одним и тем же тегом. Поэтому здесь строится новый dict
+    routing (с новыми списками balancers/rules) и присваивается обратно в
+    config["routing"], не трогая переданный в config исходный shared-объект.
     """
-    routing = config.setdefault("routing", {})
-    routing["balancers"] = routing.get("balancers", []) + [build_balancer()]
-    routing["rules"] = routing.get("rules", []) + [build_balancer_rule()]
+    routing = dict(config.get("routing") or {})
+    routing["balancers"] = list(routing.get("balancers", [])) + [build_balancer()]
+    routing["rules"] = list(routing.get("rules", [])) + [build_balancer_rule()]
+    config["routing"] = routing
     config["observatory"] = build_observatory()
     return config

--- a/app/xray/host_balancer.py
+++ b/app/xray/host_balancer.py
@@ -2,8 +2,17 @@
 
 Хост, связанный с несколькими нодами (или со статическим address через запятую),
 в формате v2ray-json отдаётся одним конфигом с N proxy-outbound (теги proxy, proxy-1, …)
-и балансировщиком strategy=random. Мёртвые ноды отсеиваются observatory: RandomStrategy
-в xray-core фильтрует кандидатов по observation, если observatory присутствует.
+и балансировщиком strategy=leastPing + observatory.
+
+Стратегия leastPing (а не random): проверено вживую — RandomStrategy в xray-core observatory
+ИГНОРИРУЕТ (прозвон идёт, но мёртвая нода остаётся в пуле → ~1/N коннектов падает). observatory
+реально учитывает только leastPing/leastLoad (как в app/xray/cascade_config.py). leastPing
+выбирает живую ноду с наименьшим пингом и автоматически обходит мёртвую (бесконечный пинг).
+Трейд-офф: это «лучшая живая нода + failover», а не равномерный разброс — но отсев мёртвых
+xray даёт только так.
+
+Проба идёт ЧЕРЕЗ ноду до probeUrl: у живой ноды (VPN-выход) google/generate_204 доступен →
+низкий пинг; мёртвая → проба падает → выпадает из пула.
 
 Без импортов БД/шаблонов — покрывается pytest без окружения (как cascade_config/bs_routing).
 """
@@ -12,10 +21,10 @@ from __future__ import annotations
 
 PROXY_OUTBOUND_TAG = "proxy"
 HOST_BALANCER_TAG = "proxy-balancer"
-HOST_BALANCER_STRATEGY = "random"
+HOST_BALANCER_STRATEGY = "leastPing"
 
 OBSERVATORY_PROBE_URL = "https://www.google.com/generate_204"
-OBSERVATORY_INTERVAL = "1m"
+OBSERVATORY_INTERVAL = "15s"
 
 
 def proxy_outbound_tag(index: int) -> str:
@@ -47,7 +56,7 @@ def build_balancer_rule() -> dict:
 
 
 def build_observatory() -> dict:
-    """Health-check proxy-outbound'ов: по нему random отсеивает мёртвые ноды."""
+    """Health-check proxy-outbound'ов: по нему leastPing выбирает живую ноду с мин. пингом."""
     return {
         "subjectSelector": [PROXY_OUTBOUND_TAG],
         "probeUrl": OBSERVATORY_PROBE_URL,

--- a/app/xray/host_balancer.py
+++ b/app/xray/host_balancer.py
@@ -2,15 +2,8 @@
 
 Хост, связанный с несколькими нодами (или со статическим address через запятую),
 в формате v2ray-json отдаётся одним конфигом с N proxy-outbound (теги proxy, proxy-1, …)
-и балансировщиком strategy=random — клиент (xray-ядро) раскидывает соединения по всем
-нодам. Это ровно рабочий путь каскада (app/xray/cascade_config.py), где random-балансировщик
-идёт БЕЗ observatory.
-
-observatory (health-check) сознательно НЕ добавляем: на живом клиенте (Happ/xray 26.x) связка
-random+observatory роняет весь проксируемый трафик — RandomStrategy фильтрует пул по observation,
-а пробы (google/generate_204 через ноды из РФ) не проходят → «живых» нод нет → балансировщик
-не выбирает ни один outbound. Отсев мёртвых нод, если понадобится, делаем серверно (как для
-БС-нод через review-джоб), а не клиентским observatory.
+и балансировщиком strategy=random. Мёртвые ноды отсеиваются observatory: RandomStrategy
+в xray-core фильтрует кандидатов по observation, если observatory присутствует.
 
 Без импортов БД/шаблонов — покрывается pytest без окружения (как cascade_config/bs_routing).
 """
@@ -20,6 +13,9 @@ from __future__ import annotations
 PROXY_OUTBOUND_TAG = "proxy"
 HOST_BALANCER_TAG = "proxy-balancer"
 HOST_BALANCER_STRATEGY = "random"
+
+OBSERVATORY_PROBE_URL = "https://www.google.com/generate_204"
+OBSERVATORY_INTERVAL = "1m"
 
 
 def proxy_outbound_tag(index: int) -> str:
@@ -50,11 +46,19 @@ def build_balancer_rule() -> dict:
     }
 
 
+def build_observatory() -> dict:
+    """Health-check proxy-outbound'ов: по нему random отсеивает мёртвые ноды."""
+    return {
+        "subjectSelector": [PROXY_OUTBOUND_TAG],
+        "probeUrl": OBSERVATORY_PROBE_URL,
+        "probeInterval": OBSERVATORY_INTERVAL,
+    }
+
+
 def apply_host_balancer(config: dict) -> dict:
-    """Дописать в собранный v2ray-json конфиг балансировщик и catch-all rule.
+    """Дописать в собранный v2ray-json конфиг балансировщик, catch-all rule и observatory.
 
     Вызывается только когда proxy-outbound'ов >1 (см. V2rayJsonConfig.add_balanced).
-    observatory НЕ добавляем (см. модульный docstring — ломает трафик на клиенте).
 
     ВАЖНО: не мутирует config["routing"] на месте — select_routing()
     (app/xray/bs_routing.py) может отдавать ОДИН И ТОТ ЖЕ routing-объект (без копии)
@@ -69,4 +73,5 @@ def apply_host_balancer(config: dict) -> dict:
     routing["balancers"] = list(routing.get("balancers", [])) + [build_balancer()]
     routing["rules"] = list(routing.get("rules", [])) + [build_balancer_rule()]
     config["routing"] = routing
+    config["observatory"] = build_observatory()
     return config

--- a/tests/test_host_balancer.py
+++ b/tests/test_host_balancer.py
@@ -46,8 +46,10 @@ def test_build_observatory_probes_proxy_prefix():
 def test_apply_host_balancer_appends_balancer_and_catch_all_last():
     config = {
         "outbounds": [
-            {"tag": "proxy"}, {"tag": "proxy-1"},
-            {"tag": "direct"}, {"tag": "block"},
+            {"tag": "proxy"},
+            {"tag": "proxy-1"},
+            {"tag": "direct"},
+            {"tag": "block"},
         ],
         "routing": {
             "rules": [
@@ -127,10 +129,22 @@ def _make_v2ray_json_config():
 
 def _inbound():
     return {
-        "network": "tcp", "protocol": "vless", "port": 443, "tls": "reality",
-        "header_type": "", "fragment_setting": "", "noise_setting": "", "path": "",
-        "sni": "example.com", "host": "", "fp": "chrome",
-        "pbk": "pbk", "sid": "0123", "spx": "", "alpn": None, "ais": "",
+        "network": "tcp",
+        "protocol": "vless",
+        "port": 443,
+        "tls": "reality",
+        "header_type": "",
+        "fragment_setting": "",
+        "noise_setting": "",
+        "path": "",
+        "sni": "example.com",
+        "host": "",
+        "fp": "chrome",
+        "pbk": "pbk",
+        "sid": "0123",
+        "spx": "",
+        "alpn": None,
+        "ais": "",
     }
 
 

--- a/tests/test_host_balancer.py
+++ b/tests/test_host_balancer.py
@@ -75,3 +75,73 @@ def test_apply_host_balancer_handles_missing_routing():
     assert result["routing"]["balancers"] == [build_balancer()]
     assert result["routing"]["rules"] == [build_balancer_rule()]
     assert result["observatory"] == build_observatory()
+
+
+import pytest
+
+
+def _make_v2ray_json_config():
+    """Инстанс V2rayJsonConfig с минимальным шаблоном.
+
+    V2rayJsonConfig.__init__ рендерит mux/user_agent/settings-шаблоны независимо от
+    template_override — если шаблонные зависимости недоступны, тест скипается (как в
+    tests/test_subscription_stubs.py::test_build_v2ray_status_stub_v2ray_json_contains_remark).
+    """
+    template = {
+        "remarks": "",
+        "outbounds": [
+            {"protocol": "freedom", "tag": "direct"},
+            {"protocol": "blackhole", "tag": "block"},
+        ],
+        "routing": {"rules": [{"type": "field", "ip": ["geoip:ru"], "outboundTag": "direct"}]},
+    }
+    try:
+        from app.subscription.v2ray import V2rayJsonConfig
+
+        return V2rayJsonConfig(template_override=template)
+    except Exception as exc:  # тяжёлые шаблонные зависимости недоступны
+        pytest.skip(f"v2ray deps unavailable: {exc}")
+
+
+def _inbound():
+    return {
+        "network": "tcp", "protocol": "vless", "port": 443, "tls": "reality",
+        "header_type": "", "fragment_setting": "", "noise_setting": "", "path": "",
+        "sni": "example.com", "host": "", "fp": "chrome",
+        "pbk": "pbk", "sid": "0123", "spx": "", "alpn": None, "ais": "",
+    }
+
+
+def _settings():
+    return {"id": "00000000-0000-0000-0000-000000000000", "flow": "xtls-rprx-vision"}
+
+
+def test_add_single_address_has_no_balancer():
+    conf = _make_v2ray_json_config()
+    conf.add(remark="Single", address="1.1.1.1", inbound=_inbound(), settings=_settings())
+    cfg = conf.config[-1]
+    proxy_tags = [o["tag"] for o in cfg["outbounds"] if o["tag"].startswith("proxy")]
+    assert proxy_tags == ["proxy"]
+    assert "balancers" not in cfg.get("routing", {})
+    assert "observatory" not in cfg
+
+
+def test_add_balanced_builds_n_proxies_balancer_and_observatory():
+    conf = _make_v2ray_json_config()
+    conf.add_balanced(
+        remark="Balance all",
+        addresses=["1.1.1.1", "2.2.2.2", "3.3.3.3"],
+        inbound=_inbound(),
+        settings=_settings(),
+    )
+    cfg = conf.config[-1]
+
+    proxy_tags = [o["tag"] for o in cfg["outbounds"] if o["tag"].startswith("proxy")]
+    assert proxy_tags == ["proxy", "proxy-1", "proxy-2"]
+    # адреса разложены по разным outbound
+    addrs = [o["settings"]["vnext"][0]["address"] for o in cfg["outbounds"] if o["tag"].startswith("proxy")]
+    assert addrs == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+    # балансировщик + catch-all последним + observatory
+    assert cfg["routing"]["balancers"] == [build_balancer()]
+    assert cfg["routing"]["rules"][-1] == build_balancer_rule()
+    assert cfg["observatory"] == build_observatory()

--- a/tests/test_host_balancer.py
+++ b/tests/test_host_balancer.py
@@ -77,6 +77,28 @@ def test_apply_host_balancer_handles_missing_routing():
     assert result["observatory"] == build_observatory()
 
 
+def test_apply_host_balancer_does_not_mutate_shared_routing():
+    # select_routing отдаёт один и тот же routing_default во все конфиги (без копии)
+    shared_routing = {"rules": [{"type": "field", "ip": ["geoip:ru"], "outboundTag": "direct"}]}
+    single_cfg = {"outbounds": [{"tag": "proxy"}], "routing": shared_routing}
+    bal_cfg_1 = {"outbounds": [{"tag": "proxy"}, {"tag": "proxy-1"}], "routing": shared_routing}
+    bal_cfg_2 = {"outbounds": [{"tag": "proxy"}, {"tag": "proxy-1"}], "routing": shared_routing}
+
+    apply_host_balancer(bal_cfg_1)
+    apply_host_balancer(bal_cfg_2)
+
+    # общий объект не тронут → одноадресный сервер чист
+    assert "balancers" not in shared_routing
+    assert shared_routing["rules"] == [{"type": "field", "ip": ["geoip:ru"], "outboundTag": "direct"}]
+    assert "balancers" not in single_cfg["routing"]
+    assert all(r.get("balancerTag") is None for r in single_cfg["routing"]["rules"])
+
+    # каждый balanced конфиг получил РОВНО ОДИН свой балансировщик
+    assert bal_cfg_1["routing"]["balancers"] == [build_balancer()]
+    assert bal_cfg_2["routing"]["balancers"] == [build_balancer()]
+    assert bal_cfg_1["routing"]["rules"][-1] == build_balancer_rule()
+
+
 import pytest
 
 

--- a/tests/test_host_balancer.py
+++ b/tests/test_host_balancer.py
@@ -7,6 +7,7 @@ from app.xray.host_balancer import (
     apply_host_balancer,
     build_balancer,
     build_balancer_rule,
+    build_observatory,
     proxy_outbound_tag,
 )
 
@@ -35,6 +36,13 @@ def test_build_balancer_rule_is_catch_all_tcp_udp():
     assert "outboundTag" not in rule
 
 
+def test_build_observatory_probes_proxy_prefix():
+    obs = build_observatory()
+    assert obs["subjectSelector"] == ["proxy"]
+    assert obs["probeUrl"]
+    assert obs["probeInterval"]
+
+
 def test_apply_host_balancer_appends_balancer_and_catch_all_last():
     config = {
         "outbounds": [
@@ -59,8 +67,8 @@ def test_apply_host_balancer_appends_balancer_and_catch_all_last():
     assert rules[-1] == build_balancer_rule()
     assert rules[0]["outboundTag"] == "block"
     assert rules[1]["outboundTag"] == "direct"
-    # observatory НЕ добавляем (ломает трафик на клиенте — см. host_balancer docstring)
-    assert "observatory" not in result
+    # observatory на верхнем уровне
+    assert result["observatory"] == build_observatory()
 
 
 def test_apply_host_balancer_handles_missing_routing():
@@ -68,7 +76,7 @@ def test_apply_host_balancer_handles_missing_routing():
     result = apply_host_balancer(config)
     assert result["routing"]["balancers"] == [build_balancer()]
     assert result["routing"]["rules"] == [build_balancer_rule()]
-    assert "observatory" not in result
+    assert result["observatory"] == build_observatory()
 
 
 def test_apply_host_balancer_does_not_mutate_shared_routing():
@@ -154,7 +162,7 @@ def test_add_single_address_has_no_balancer():
     assert "observatory" not in cfg
 
 
-def test_add_balanced_builds_n_proxies_and_balancer():
+def test_add_balanced_builds_n_proxies_balancer_and_observatory():
     conf = _make_v2ray_json_config()
     conf.add_balanced(
         remark="Balance all",
@@ -169,7 +177,7 @@ def test_add_balanced_builds_n_proxies_and_balancer():
     # адреса разложены по разным outbound
     addrs = [o["settings"]["vnext"][0]["address"] for o in cfg["outbounds"] if o["tag"].startswith("proxy")]
     assert addrs == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
-    # балансировщик + catch-all последним, БЕЗ observatory
+    # балансировщик + catch-all последним + observatory
     assert cfg["routing"]["balancers"] == [build_balancer()]
     assert cfg["routing"]["rules"][-1] == build_balancer_rule()
-    assert "observatory" not in cfg
+    assert cfg["observatory"] == build_observatory()

--- a/tests/test_host_balancer.py
+++ b/tests/test_host_balancer.py
@@ -7,7 +7,6 @@ from app.xray.host_balancer import (
     apply_host_balancer,
     build_balancer,
     build_balancer_rule,
-    build_observatory,
     proxy_outbound_tag,
 )
 
@@ -36,13 +35,6 @@ def test_build_balancer_rule_is_catch_all_tcp_udp():
     assert "outboundTag" not in rule
 
 
-def test_build_observatory_probes_proxy_prefix():
-    obs = build_observatory()
-    assert obs["subjectSelector"] == ["proxy"]
-    assert obs["probeUrl"]
-    assert obs["probeInterval"]
-
-
 def test_apply_host_balancer_appends_balancer_and_catch_all_last():
     config = {
         "outbounds": [
@@ -67,8 +59,8 @@ def test_apply_host_balancer_appends_balancer_and_catch_all_last():
     assert rules[-1] == build_balancer_rule()
     assert rules[0]["outboundTag"] == "block"
     assert rules[1]["outboundTag"] == "direct"
-    # observatory на верхнем уровне
-    assert result["observatory"] == build_observatory()
+    # observatory НЕ добавляем (ломает трафик на клиенте — см. host_balancer docstring)
+    assert "observatory" not in result
 
 
 def test_apply_host_balancer_handles_missing_routing():
@@ -76,7 +68,7 @@ def test_apply_host_balancer_handles_missing_routing():
     result = apply_host_balancer(config)
     assert result["routing"]["balancers"] == [build_balancer()]
     assert result["routing"]["rules"] == [build_balancer_rule()]
-    assert result["observatory"] == build_observatory()
+    assert "observatory" not in result
 
 
 def test_apply_host_balancer_does_not_mutate_shared_routing():
@@ -162,7 +154,7 @@ def test_add_single_address_has_no_balancer():
     assert "observatory" not in cfg
 
 
-def test_add_balanced_builds_n_proxies_balancer_and_observatory():
+def test_add_balanced_builds_n_proxies_and_balancer():
     conf = _make_v2ray_json_config()
     conf.add_balanced(
         remark="Balance all",
@@ -177,7 +169,7 @@ def test_add_balanced_builds_n_proxies_balancer_and_observatory():
     # адреса разложены по разным outbound
     addrs = [o["settings"]["vnext"][0]["address"] for o in cfg["outbounds"] if o["tag"].startswith("proxy")]
     assert addrs == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
-    # балансировщик + catch-all последним + observatory
+    # балансировщик + catch-all последним, БЕЗ observatory
     assert cfg["routing"]["balancers"] == [build_balancer()]
     assert cfg["routing"]["rules"][-1] == build_balancer_rule()
-    assert cfg["observatory"] == build_observatory()
+    assert "observatory" not in cfg

--- a/tests/test_host_balancer.py
+++ b/tests/test_host_balancer.py
@@ -1,0 +1,77 @@
+"""Чистые билдеры xray-балансировщика для multi-address хостов (NPVPN-1596)."""
+
+from __future__ import annotations
+
+from app.xray.host_balancer import (
+    HOST_BALANCER_TAG,
+    apply_host_balancer,
+    build_balancer,
+    build_balancer_rule,
+    build_observatory,
+    proxy_outbound_tag,
+)
+
+
+def test_proxy_outbound_tag_first_is_plain_proxy():
+    assert proxy_outbound_tag(0) == "proxy"
+
+
+def test_proxy_outbound_tag_rest_are_suffixed():
+    assert proxy_outbound_tag(1) == "proxy-1"
+    assert proxy_outbound_tag(2) == "proxy-2"
+
+
+def test_build_balancer_random_over_proxy_prefix():
+    bal = build_balancer()
+    assert bal["tag"] == HOST_BALANCER_TAG
+    assert bal["selector"] == ["proxy"]
+    assert bal["strategy"] == {"type": "random"}
+
+
+def test_build_balancer_rule_is_catch_all_tcp_udp():
+    rule = build_balancer_rule()
+    assert rule["type"] == "field"
+    assert rule["network"] == "tcp,udp"
+    assert rule["balancerTag"] == HOST_BALANCER_TAG
+    assert "outboundTag" not in rule
+
+
+def test_build_observatory_probes_proxy_prefix():
+    obs = build_observatory()
+    assert obs["subjectSelector"] == ["proxy"]
+    assert obs["probeUrl"]
+    assert obs["probeInterval"]
+
+
+def test_apply_host_balancer_appends_balancer_and_catch_all_last():
+    config = {
+        "outbounds": [
+            {"tag": "proxy"}, {"tag": "proxy-1"},
+            {"tag": "direct"}, {"tag": "block"},
+        ],
+        "routing": {
+            "rules": [
+                {"type": "field", "domain": ["geosite:category-ads-all"], "outboundTag": "block"},
+                {"type": "field", "ip": ["geoip:ru"], "outboundTag": "direct"},
+            ],
+        },
+    }
+    result = apply_host_balancer(config)
+
+    # балансировщик добавлен
+    assert result["routing"]["balancers"] == [build_balancer()]
+    # catch-all — последним, прежние правила сохранены и раньше
+    rules = result["routing"]["rules"]
+    assert rules[-1] == build_balancer_rule()
+    assert rules[0]["outboundTag"] == "block"
+    assert rules[1]["outboundTag"] == "direct"
+    # observatory на верхнем уровне
+    assert result["observatory"] == build_observatory()
+
+
+def test_apply_host_balancer_handles_missing_routing():
+    config = {"outbounds": [{"tag": "proxy"}, {"tag": "proxy-1"}]}
+    result = apply_host_balancer(config)
+    assert result["routing"]["balancers"] == [build_balancer()]
+    assert result["routing"]["rules"] == [build_balancer_rule()]
+    assert result["observatory"] == build_observatory()

--- a/tests/test_host_balancer.py
+++ b/tests/test_host_balancer.py
@@ -21,11 +21,11 @@ def test_proxy_outbound_tag_rest_are_suffixed():
     assert proxy_outbound_tag(2) == "proxy-2"
 
 
-def test_build_balancer_random_over_proxy_prefix():
+def test_build_balancer_leastping_over_proxy_prefix():
     bal = build_balancer()
     assert bal["tag"] == HOST_BALANCER_TAG
     assert bal["selector"] == ["proxy"]
-    assert bal["strategy"] == {"type": "random"}
+    assert bal["strategy"] == {"type": "leastPing"}
 
 
 def test_build_balancer_rule_is_catch_all_tcp_udp():


### PR DESCRIPTION
## Что и зачем

Хост подписки, связанный с несколькими нодами (multi-address), в формате v2ray-json отдавал **один** proxy-outbound со случайной нодой (`random.choice` на каждый запрос подписки) — настоящей балансировки не было (адрес «Balance all» скакал от запроса к запросу). Теперь такой хост отдаётся **одним** конфигом-сервером с N proxy-outbound и настоящим xray-балансировщиком (`strategy: random` + `observatory`): клиент (Happ/xray) сам раскидывает соединения по всем нодам и исключает недоступные.

## Изменения

- Новый чистый модуль `app/xray/host_balancer.py` (по образцу `cascade_config.py`/`bs_routing.py`, без БД/шаблонов): билдеры `balancer`/`observatory`/catch-all-правила + `apply_host_balancer(config)`.
- `V2rayJsonConfig.add_balanced` (`app/subscription/v2ray.py`): N proxy-outbound (`proxy`, `proxy-1`, …) + `routing.balancers` (селектор `["proxy"]`) + catch-all `balancerTag`-правило последним + top-level `observatory`. Извлечены `_build_proxy_outbound`/`_assemble_config` — одноадресный `add()` остаётся **байт-в-байт** прежним.
- `app/subscription/share.py`: для v2ray-json и `>1` адреса → `add_balanced`, иначе прежний `random.choice`. Форматы v2ray/clash/singbox не тронуты.
- Тесты `tests/test_host_balancer.py` (чистые билдеры + skip-guarded генерация V2rayJsonConfig).

## Заметки для ревью

- Балансировщик **только для v2ray-json** (xray-core клиенты: Happ/v2rayNG/streisand/v2rayN); в vmess/vless-ссылках, clash, singbox невыразим.
- Стратегия `random` + `observatory` (`subjectSelector: ["proxy"]`): мёртвые ноды отсеиваются health-check'ом (`RandomStrategy` в xray-core фильтрует по observation). **Отсев зависит от версии xray-core форка — валидировать реальным curl к Happ + погашенной нодой ДО раската на прод.**
- Ручная стейдж-проверка: деплой на rutest + `curl -H "User-Agent: Happ/2.0.0" .../sub/<token>` — «Balance all» должен отдать N proxy-outbound + `balancers` + `observatory` + catch-all `balancerTag`-правило последним.
- Fix в ходе ревью (Critical): `apply_host_balancer` работает с копией routing и не мутирует общий `routing_default`/`routing_bs` — иначе балансировщик протекал в одноадресные конфиги и дублировал тег `proxy-balancer` при 2+ multi-address хостах (гейт — заданный `sub_routing_json_default`).
- Defer (не блокеры): `is_bs` на balanced-пути не форсится в `False` (multi-address + bs-адрес → `routing_bs`; на практике «Balance all» и БС-ноды не смешиваются). Кастомный финальный catch-all в `sub_routing_json_default` может «затенить» правило балансировщика.
- Без миграций БД, изменений UI дашборда и env.
