### PR TITLE
NPVPN-1598: управление инбаундами главного сервера (Master) как у нод

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -6,6 +6,8 @@
   "core.configuration": "Configuration",
   "core.generalErrorMessage": "Something went wrong, please check the configuration",
   "core.logs": "Logs",
+  "core.masterInbounds": "Master inbounds",
+  "core.masterInboundsHint": "Empty — all inbounds are started on the main server.",
   "core.restartCore": "Restart Core",
   "core.restarting": "Restarting...",
   "core.save": "Save",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -6,6 +6,8 @@
   "core.configuration": "Конфигурация",
   "core.generalErrorMessage": "Что-то пошло не так, пожалуйста, проверьте конфигурацию",
   "core.logs": "Логи",
+  "core.masterInbounds": "Инбаунды Master",
+  "core.masterInboundsHint": "Пусто — на главном сервере поднимаются все инбаунды.",
   "core.restartCore": "Перезагрузить ядро",
   "core.restarting": "Перезагрузка...",
   "core.save": "Сохранить",

--- a/app/dashboard/src/components/CoreSettingsModal.tsx
+++ b/app/dashboard/src/components/CoreSettingsModal.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   chakra,
+  Checkbox,
   CircularProgress,
   FormControl,
   FormLabel,
@@ -19,7 +20,8 @@ import {
   Text,
   Tooltip,
   useToast,
-  useColorMode
+  useColorMode,
+  VStack
 } from "@chakra-ui/react";
 import {
   ArrowPathIcon,
@@ -32,13 +34,14 @@ import classNames from "classnames";
 import { useCoreSettings } from "contexts/CoreSettingsContext";
 import { useDashboard } from "contexts/DashboardContext";
 import debounce from "lodash.debounce";
-import { FC, useCallback, useEffect, useRef, useState } from "react";
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-query";
 import { ReadyState } from "react-use-websocket";
 import { useWebSocket } from "react-use-websocket/dist/lib/use-websocket";
 import { getAuthToken } from "utils/authStorage";
+import { getMasterInbounds, setMasterInbounds } from "service/master";
 import { Icon } from "./Icon";
 import { JsonEditor } from "./JsonEditor";
 import "./JsonEditor/themes.js";
@@ -126,7 +129,7 @@ const CoreSettingModalContent: FC = () => {
     }
   };
 
-  const { isEditingCore } = useDashboard();
+  const { isEditingCore, inbounds: allInbounds } = useDashboard();
   const {
     fetchCoreSettings,
     updateConfig,
@@ -136,6 +139,56 @@ const CoreSettingModalContent: FC = () => {
     version,
     restartCore,
   } = useCoreSettings();
+  const inboundTags = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          Array.from(allInbounds.values())
+            .flat()
+            .map((i) => i.tag)
+        )
+      ),
+    [allInbounds]
+  );
+  const [masterInbounds, setMasterInboundsState] = useState<string[]>([]);
+  const [savingMaster, setSavingMaster] = useState(false);
+
+  useEffect(() => {
+    if (isEditingCore)
+      getMasterInbounds()
+        .then((r) => setMasterInboundsState(r.inbounds))
+        .catch(() => void 0);
+  }, [isEditingCore]);
+
+  const toggleMasterInbound = (tag: string, checked: boolean) =>
+    setMasterInboundsState((prev) =>
+      checked ? [...prev, tag] : prev.filter((x) => x !== tag)
+    );
+
+  const handleSaveMaster = () => {
+    setSavingMaster(true);
+    setMasterInbounds(masterInbounds)
+      .then((r) => {
+        setMasterInboundsState(r.inbounds);
+        toast({
+          title: t("core.successMessage"),
+          status: "success",
+          isClosable: true,
+          position: "top",
+          duration: 3000,
+        });
+      })
+      .catch(() =>
+        toast({
+          title: t("core.generalErrorMessage"),
+          status: "error",
+          isClosable: true,
+          position: "top",
+          duration: 3000,
+        })
+      )
+      .finally(() => setSavingMaster(false));
+  };
   const logsDiv = useRef<HTMLDivElement | null>(null);
   const [logs, setLogs] = useState<string[]>([]);
   const { t } = useTranslation();
@@ -340,6 +393,37 @@ const CoreSettingModalContent: FC = () => {
             ))}
           </Box>
         </FormControl>
+        {inboundTags.length > 0 && (
+          <FormControl mt="4">
+            <FormLabel>{t("core.masterInbounds", "Инбаунды Master")}</FormLabel>
+            <Text fontSize="xs" opacity={0.7} mb={2}>
+              {t(
+                "core.masterInboundsHint",
+                "Пусто — на главном сервере поднимаются все инбаунды."
+              )}
+            </Text>
+            <VStack align="flex-start" spacing={1}>
+              {inboundTags.map((tag) => (
+                <Checkbox
+                  key={tag}
+                  isChecked={masterInbounds.includes(tag)}
+                  onChange={(e) => toggleMasterInbound(tag, e.target.checked)}
+                >
+                  <Text fontSize="sm">{tag}</Text>
+                </Checkbox>
+              ))}
+            </VStack>
+            <Button
+              size="sm"
+              mt={2}
+              variant="outline"
+              isLoading={savingMaster}
+              onClick={handleSaveMaster}
+            >
+              {t("core.save")}
+            </Button>
+          </FormControl>
+        )}
       </ModalBody>
       <ModalFooter>
         <HStack w="full" justifyContent="space-between">

--- a/app/dashboard/src/components/CoreSettingsModal.tsx
+++ b/app/dashboard/src/components/CoreSettingsModal.tsx
@@ -139,6 +139,11 @@ const CoreSettingModalContent: FC = () => {
     version,
     restartCore,
   } = useCoreSettings();
+  const logsDiv = useRef<HTMLDivElement | null>(null);
+  const [logs, setLogs] = useState<string[]>([]);
+  const { t } = useTranslation();
+  const toast = useToast();
+
   const inboundTags = useMemo(
     () =>
       Array.from(
@@ -151,13 +156,27 @@ const CoreSettingModalContent: FC = () => {
     [allInbounds]
   );
   const [masterInbounds, setMasterInboundsState] = useState<string[]>([]);
+  const [masterLoaded, setMasterLoaded] = useState(false);
   const [savingMaster, setSavingMaster] = useState(false);
 
   useEffect(() => {
-    if (isEditingCore)
+    if (isEditingCore) {
+      setMasterLoaded(false);
       getMasterInbounds()
-        .then((r) => setMasterInboundsState(r.inbounds))
-        .catch(() => void 0);
+        .then((r) => {
+          setMasterInboundsState(r.inbounds);
+          setMasterLoaded(true);
+        })
+        .catch(() =>
+          toast({
+            title: t("core.generalErrorMessage"),
+            status: "error",
+            isClosable: true,
+            position: "top",
+            duration: 3000,
+          })
+        );
+    }
   }, [isEditingCore]);
 
   const toggleMasterInbound = (tag: string, checked: boolean) =>
@@ -189,10 +208,6 @@ const CoreSettingModalContent: FC = () => {
       )
       .finally(() => setSavingMaster(false));
   };
-  const logsDiv = useRef<HTMLDivElement | null>(null);
-  const [logs, setLogs] = useState<string[]>([]);
-  const { t } = useTranslation();
-  const toast = useToast();
   const form = useForm({
     defaultValues: { config: config || {} },
   });
@@ -418,6 +433,7 @@ const CoreSettingModalContent: FC = () => {
               mt={2}
               variant="outline"
               isLoading={savingMaster}
+              isDisabled={!masterLoaded}
               onClick={handleSaveMaster}
             >
               {t("core.save")}

--- a/app/dashboard/src/service/master.ts
+++ b/app/dashboard/src/service/master.ts
@@ -1,0 +1,9 @@
+import { fetch } from "./http";
+
+export type MasterInbounds = { inbounds: string[] };
+
+export const getMasterInbounds = () =>
+  fetch<MasterInbounds>("/master/inbounds");
+
+export const setMasterInbounds = (inbounds: string[]) =>
+  fetch<MasterInbounds>("/master/inbounds", { method: "PUT", body: { inbounds } });

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -35,6 +35,7 @@ from app.db.models import (
     UserDevice,
     UserTemplate,
     UserUsageResetLogs,
+    master_inbounds_association,
 )
 from app.models.admin import AdminCreate, AdminModify, AdminPartialModify
 from app.models.bot import apply_bot_settings_fallback
@@ -1825,6 +1826,21 @@ def update_node(db: Session, dbnode: Node, modify: NodeModify) -> Node:
     db.commit()
     db.refresh(dbnode)
     return dbnode
+
+
+def get_master_inbound_tags(db: Session) -> list[str]:
+    """Теги инбаундов, назначенных главному серверу (Master). Пусто ⇒ все инбаунды."""
+    return [row[0] for row in db.query(master_inbounds_association.c.inbound_tag).all()]
+
+
+def set_master_inbounds(db: Session, tags: list[str]) -> None:
+    """Переустановить набор инбаундов Master (полная замена)."""
+    for tag in tags:
+        get_or_create_inbound(db, tag)  # гарантировать наличие inbounds.tag под FK
+    db.execute(master_inbounds_association.delete())
+    if tags:
+        db.execute(master_inbounds_association.insert(), [{"inbound_tag": t} for t in tags])
+    db.commit()
 
 
 def update_node_status(db: Session, dbnode: Node, status: NodeStatus, message: str = None, version: str = None) -> Node:

--- a/app/db/migrations/versions/2c0cafb40725_master_inbounds_association.py
+++ b/app/db/migrations/versions/2c0cafb40725_master_inbounds_association.py
@@ -1,0 +1,33 @@
+"""master inbounds association
+
+Revision ID: 2c0cafb40725
+Revises: a7b8c9d0e1f2
+Create Date: 2026-07-08 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2c0cafb40725'
+down_revision = 'a7b8c9d0e1f2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # FK на inbounds.tag (utf8mb4_bin на MySQL). См. 5a20cee1a4e9.
+    bind = op.get_bind()
+    tag_collation = "utf8mb4_bin" if bind.engine.name == "mysql" else None
+
+    op.create_table(
+        "master_inbounds",
+        sa.Column("inbound_tag", sa.String(length=256, collation=tag_collation), nullable=False),
+        sa.ForeignKeyConstraint(["inbound_tag"], ["inbounds.tag"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("inbound_tag"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("master_inbounds")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -261,6 +261,12 @@ node_inbounds_association = Table(
     Column("inbound_tag", ForeignKey("inbounds.tag", ondelete="CASCADE"), primary_key=True),
 )
 
+master_inbounds_association = Table(
+    "master_inbounds",
+    Base.metadata,
+    Column("inbound_tag", ForeignKey("inbounds.tag", ondelete="CASCADE"), primary_key=True),
+)
+
 
 class CascadeRoute(Base):
     """Связь входной ноды с выходной по конкретному инбаунду (NPVPN-1472).

--- a/app/jobs/0_xray_core.py
+++ b/app/jobs/0_xray_core.py
@@ -103,6 +103,9 @@ def start_core():
     config = xray.config.include_db_users()
     logger.info(f"Xray core config generated in {(time.time() - start_time):.2f} seconds")
 
+    with GetDB() as db:
+        xray.operations.refresh_master_inbounds(db)
+
     # main core
     logger.info("Starting main Xray core")
     try:

--- a/app/models/core.py
+++ b/app/models/core.py
@@ -5,3 +5,7 @@ class CoreStats(BaseModel):
     version: str
     started: bool
     logs_websocket: str
+
+
+class MasterInbounds(BaseModel):
+    inbounds: list[str] = []

--- a/app/routers/core.py
+++ b/app/routers/core.py
@@ -7,9 +7,9 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket
 from starlette.websockets import WebSocketDisconnect
 
 from app import xray
-from app.db import Session, get_db
+from app.db import Session, crud, get_db
 from app.models.admin import Admin
-from app.models.core import CoreStats
+from app.models.core import CoreStats, MasterInbounds
 from app.utils import responses
 from app.xray import XRayConfig
 from config import XRAY_JSON
@@ -124,3 +124,29 @@ def modify_core_config(payload: dict, admin: Admin = Depends(Admin.check_sudo_ad
     xray.hosts.update()
 
     return payload
+
+
+@router.get("/master/inbounds", response_model=MasterInbounds, responses={403: responses._403})
+def get_master_inbounds(
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.check_sudo_admin),
+) -> MasterInbounds:
+    """Инбаунды, поднятые на главном сервере (Master). Пусто ⇒ все инбаунды."""
+    return MasterInbounds(inbounds=crud.get_master_inbound_tags(db))
+
+
+@router.put("/master/inbounds", response_model=MasterInbounds, responses={403: responses._403})
+def modify_master_inbounds(
+    payload: MasterInbounds,
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.check_sudo_admin),
+) -> MasterInbounds:
+    """Задать инбаунды Master и перезапустить главный core (ноды не трогаем)."""
+    # оставить только известные прокси-инбаунды (неизвестные молча отбрасываем)
+    known = set(xray.config.inbounds_by_tag.keys())
+    tags = [t for t in payload.inbounds if t in known]
+
+    crud.set_master_inbounds(db, tags)
+    xray.operations.refresh_master_inbounds(db)
+    xray.core.restart(xray.config.include_db_users())
+    return MasterInbounds(inbounds=tags)

--- a/app/xray/__init__.py
+++ b/app/xray/__init__.py
@@ -9,6 +9,7 @@ from app.xray import operations
 from app.xray.config import XRayConfig
 from app.xray.core import XRayCore
 from app.xray.host_addresses import resolve_host_addresses
+from app.xray.inbound_filter import apply_inbound_filter
 from app.xray.node import XRayNode
 from config import XRAY_ASSETS_PATH, XRAY_EXECUTABLE_PATH, XRAY_JSON
 from xray_api import XRay as XRayAPI
@@ -29,6 +30,12 @@ finally:
 api = XRayAPI(config.api_host, config.api_port)
 
 nodes: dict[int, XRayNode] = {}
+
+# Кеш тегов инбаундов Master (пусто ⇒ Master поднимает все инбаунды).
+# Обновляется через operations.refresh_master_inbounds(db).
+master_inbound_tags: list[str] = []
+
+core.inbound_filter = lambda cfg: apply_inbound_filter(cfg, master_inbound_tags)
 
 
 if TYPE_CHECKING:
@@ -76,6 +83,7 @@ __all__ = [
     "core",
     "api",
     "nodes",
+    "master_inbound_tags",
     "operations",
     "exceptions",
     "exc",

--- a/app/xray/__init__.py
+++ b/app/xray/__init__.py
@@ -35,7 +35,10 @@ nodes: dict[int, XRayNode] = {}
 # Обновляется через operations.refresh_master_inbounds(db).
 master_inbound_tags: list[str] = []
 
-core.inbound_filter = lambda cfg: apply_inbound_filter(cfg, master_inbound_tags)
+# list(...) — снимок на момент вызова: refresh_master_inbounds мутирует список
+# in-place (master_inbound_tags[:] = ...), а хук может читаться из потока
+# APScheduler (core_health_check) параллельно с PUT-обновлением.
+core.inbound_filter = lambda cfg: apply_inbound_filter(cfg, list(master_inbound_tags))
 
 
 if TYPE_CHECKING:

--- a/app/xray/core.py
+++ b/app/xray/core.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import threading
 from collections import deque
+from collections.abc import Callable
 from contextlib import contextmanager
 
 from app import logger
@@ -18,6 +19,7 @@ class XRayCore:
         self.version = self.get_version()
         self.process = None
         self.restarting = False
+        self.inbound_filter: Callable[[XRayConfig], XRayConfig] | None = None  # применяется в start()
 
         self._logs_buffer = deque(maxlen=100)
         self._temp_log_buffers = {}
@@ -104,6 +106,9 @@ class XRayCore:
     def start(self, config: XRayConfig):
         if self.started is True:
             raise RuntimeError("Xray is started already")
+
+        if self.inbound_filter is not None:
+            config = self.inbound_filter(config)
 
         if config.get("log", {}).get("logLevel") in ("none", "error"):
             config["log"]["logLevel"] = "warning"

--- a/app/xray/inbound_filter.py
+++ b/app/xray/inbound_filter.py
@@ -26,3 +26,21 @@ def filtered_inbounds(
     managed = set(managed_tags)
     allowed = set(allowed_tags)
     return [inbound for inbound in inbounds if inbound["tag"] not in managed or inbound["tag"] in allowed]
+
+
+def apply_inbound_filter(base_config, allowed_tags):
+    """Config-level фильтр инбаундов (общий для нод и главного core).
+
+    allowed_tags пуст/None → base_config без изменений (обратная совместимость:
+    поднимаются все инбаунды). Иначе — base_config.copy() с оставленными
+    инфраструктурными инбаундами и разрешёнными управляемыми (allowed_tags).
+    """
+    if not allowed_tags:
+        return base_config
+    cfg = base_config.copy()
+    cfg["inbounds"] = filtered_inbounds(
+        cfg["inbounds"],
+        managed_tags=set(base_config.inbounds_by_tag.keys()),
+        allowed_tags=set(allowed_tags),
+    )
+    return cfg

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -12,7 +12,7 @@ from app.models.user import UserResponse
 from app.utils.concurrency import threaded_function
 from app.xray.bs_limit import strip_blocked_clients
 from app.xray.cascade_config import cascade_config
-from app.xray.inbound_filter import filtered_inbounds
+from app.xray.inbound_filter import apply_inbound_filter
 from app.xray.node import XRayNode
 from config import (
     XRAY_NODE_CONNECT_RETRIES,
@@ -467,23 +467,11 @@ def _cascade_kwargs(db, dbnode) -> dict:
 def _node_specific_config(base_config, node_inbound_tags):
     """Вернуть конфиг для конкретной ноды.
 
-    node_inbound_tags пуст/None → возвращаем base_config без изменений
+    node_inbound_tags пуст/None → base_config без изменений
     (обратная совместимость: нода получает все инбаунды).
-    Иначе — копия конфига, в которой оставлены только инфраструктурные
-    инбаунды и назначенные ноде прокси-инбаунды.
+    Иначе — копия с инфраструктурными + назначенными ноде инбаундами.
     """
-    if not node_inbound_tags:
-        return base_config
-    node_config = base_config.copy()  # deepcopy → остаётся XRayConfig с to_json()
-    # managed_tags — только прокси-инбаунды (inbounds_by_tag). Инфраструктурные
-    # инбаунды (API_INBOUND, fallback, XRAY_EXCLUDE_INBOUND_TAGS) в managed не входят,
-    # поэтому остаются на каждой ноде всегда, независимо от назначений.
-    node_config["inbounds"] = filtered_inbounds(
-        node_config["inbounds"],
-        managed_tags=set(base_config.inbounds_by_tag.keys()),
-        allowed_tags=set(node_inbound_tags),
-    )
-    return node_config
+    return apply_inbound_filter(base_config, node_inbound_tags)
 
 
 def remove_node(node_id: int):

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -68,6 +68,13 @@ def get_tls():
         return {"key": tls.key, "certificate": tls.certificate}
 
 
+def refresh_master_inbounds(db):
+    """Перечитать теги инбаундов Master из БД в кеш xray.master_inbound_tags (in-place)."""
+    from app import xray
+
+    xray.master_inbound_tags[:] = crud.get_master_inbound_tags(db)
+
+
 @threaded_function
 def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
     try:

--- a/tests/test_inbound_filter.py
+++ b/tests/test_inbound_filter.py
@@ -36,3 +36,50 @@ def test_does_not_mutate_input():
 def test_unknown_allowed_tag_ignored():
     result = filtered_inbounds(INBOUNDS, managed_tags=MANAGED, allowed_tags={"NOPE"})
     assert [i["tag"] for i in result] == ["API_INBOUND"]
+
+
+from app.xray.inbound_filter import apply_inbound_filter
+
+
+class FakeConfig(dict):
+    """Мимикрия XRayConfig: dict + .copy() (deep) + .inbounds_by_tag."""
+
+    def __init__(self, *args, inbounds_by_tag=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._inbounds_by_tag = inbounds_by_tag or {}
+
+    @property
+    def inbounds_by_tag(self):
+        return self._inbounds_by_tag
+
+    def copy(self):
+        clone = FakeConfig(inbounds_by_tag=self._inbounds_by_tag)
+        clone["inbounds"] = [dict(i) for i in self["inbounds"]]
+        return clone
+
+
+def _base_config():
+    return FakeConfig(
+        {"inbounds": [dict(i) for i in INBOUNDS]},
+        inbounds_by_tag={tag: {} for tag in MANAGED},
+    )
+
+
+def test_apply_empty_returns_same_object():
+    cfg = _base_config()
+    assert apply_inbound_filter(cfg, []) is cfg
+
+
+def test_apply_subset_keeps_infra_and_allowed():
+    cfg = _base_config()
+    result = apply_inbound_filter(cfg, ["VLESS_TCP"])
+    assert result is not cfg
+    assert [i["tag"] for i in result["inbounds"]] == ["API_INBOUND", "VLESS_TCP"]
+    # исходный конфиг не мутирован
+    assert [i["tag"] for i in cfg["inbounds"]] == [i["tag"] for i in INBOUNDS]
+
+
+def test_apply_unknown_tag_ignored():
+    cfg = _base_config()
+    result = apply_inbound_filter(cfg, ["NOPE"])
+    assert [i["tag"] for i in result["inbounds"]] == ["API_INBOUND"]


### PR DESCRIPTION
## Суть

Теперь можно выбирать, какие инбаунды реально поднимаются на самом сервере marzban (главном xray-core, «Master») — так же, как это уже делается для нод. Раньше главный core всегда стартовал с полным `XRAY_JSON` (все инбаунды).

Задача: [NPVPN-1598](https://ru.yougile.com/team/9a0e05abf438/#NPVPN-1598).

## Что сделано

- **Ядро фильтра.** Вынесена чистая config-level функция `apply_inbound_filter` в `app/xray/inbound_filter.py`; существующий фильтр нод `_node_specific_config` делегирует в неё (DRY, без изменения поведения нод).
- **Хранение.** Новая таблица `master_inbounds` (зеркало `node_inbounds`) + CRUD `get_master_inbound_tags` / `set_master_inbounds`. Миграция `2c0cafb40725` (collation `utf8mb4_bin` на MySQL, как у `node_inbounds`).
- **Рантайм.** Кеш `xray.master_inbound_tags` + `refresh_master_inbounds(db)` (обновляет in-place) и единый барьер — хук `XRayCore.inbound_filter`, применяемый внутри `XRayCore.start()`. Любой старт/рестарт главного core проходит через фильтр; ~7 call-site'ов не тронуты. Ноды используют `XRayNode` — не затронуты.
- **API.** Sudo-ручки `GET`/`PUT /api/master/inbounds` в `app/routers/core.py` + модель `MasterInbounds`. PUT валидирует теги против `xray.config.inbounds_by_tag` (неизвестные молча отбрасываются), сохраняет, обновляет кеш и рестартует только главный core.
- **UI.** `service/master.ts` + секция «Инбаунды Master» с чекбоксами в модалке Core Settings. Есть защита от случайной перезаписи выбора пустым списком при ошибке загрузки.

**Обратная совместимость:** пустой набор ⇒ Master поднимает все инбаунды (текущее поведение). Инфраструктурные инбаунды (`API_INBOUND`, fallback и т.п.) фильтр не трогает — остаются всегда.

**Осознанно вне объёма:** роли/каскад для Master.

## Тесты и проверки

- Юнит-тесты фильтра: `tests/test_inbound_filter.py` — 8 новых кейсов (пусто = все, подмножество = выбранные + инфраструктурные, отсутствие мутации входа). Полный набор панели: **119 passed, 3 skipped**.
- Миграция прогнана `upgrade→downgrade→upgrade` на sqlite; CRUD проверен вручную.
- ruff clean, mypy-baseline не вырос, фронт `tsc --noEmit` без ошибок.
- Финальное ревью всей ветки: без Critical/Important; теоретическая гонка health-check↔PUT закрыта снапшотом списка в хуке.

## Проверить на стенде перед мержем

- Прогнать миграцию `master_inbounds` один раз на реальном MySQL (`nvb_mysql`) — ветка collation не тестировалась на живой БД.
- Live-смоук: `GET`/`PUT /api/master/inbounds` (sudo) и UI-секция в Core Settings.

## Известный безобидный кейс

Операции add/remove пользователя на главном core шлют на `xray.api` по всем инбаундам юзера; если инбаунд не поднят на Master — вернётся идемпотентный `EmailNotFound`. Вне объёма задачи.
