### PR TITLE
NPVPN-1533: поддержка extra-параметров для xhttp (per-host, 1:1)

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -65,6 +65,7 @@
   "hostsDialog.noise.info": "Correct pattern: packets,delay",
   "hostsDialog.noise.info.attention": "Attention: currently, this feature only supported in streisand >= 1.6.32 and v2rayNG >= 1.8.39 (custom config)",
   "hostsDialog.noise.info.examples": "Examples:",
+  "hostsDialog.xhttpExtra": "xHTTP extra (JSON)",
   "hostsDialog.host": "Request Host",
   "hostsDialog.host.info": "By default, if a request host is set in the Xray config, this host is used. However, you can set a custom request host here if needed.",
   "hostsDialog.host.multiHost": "To set multiple addresses, separate them with <badge>,</badge> Each time an address is chosen randomly.",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -70,6 +70,7 @@
   "hostsDialog.noise.info": "packet,delay (e.g. rand:10-20,100-200)",
   "hostsDialog.noise.info.attention": "توجه: در حال حاضر، این ویژگی فقط در streisand >= 1.6.32 و v2rayNG >= 1.8.39 (پیکربندی سفارشی) پشتیبانی می شود",
   "hostsDialog.noise.info.examples": "نمونه ها:",
+  "hostsDialog.xhttpExtra": "xHTTP extra (JSON)",
   "hostsDialog.host": "هاست درخواست",
   "hostsDialog.host.info": "به‌طور پیش‌فرض، اگر هاست درخواستی در پیکربندی *** تنظیم شده باشد، این هاست استفاده می‌شود. اما می‌توانید یک هاست درخواستی متفاوت در اینجا قرار دهید.",
   "hostsDialog.host.multiHost": "برای تنظیم چند آدرس، با <badge>,</badge> از هم جدا کنید. هر دفعه آدرسی به صورت تصادفی قرار داده می‌شود.",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -65,6 +65,7 @@
   "hostsDialog.noise.info": "packet,delay (e.g. rand:10-20,100-200)",
   "hostsDialog.noise.info.attention": "Attention: currently, this feature only supported in streisand >= 1.6.32 and v2rayNG >= 1.8.39 (custom config)",
   "hostsDialog.noise.info.examples": "Examples:",
+  "hostsDialog.xhttpExtra": "xHTTP extra (JSON)",
   "hostsDialog.host": "Host",
   "hostsDialog.host.info": "По умолчанию, если в конфигурации XRAY задан запрашиваемый хост, то он и будет использоваться. Однако, если необходимо, вы можете установить здесь пользовательский запрашиваемый хост.",
   "hostsDialog.host.multiHost": "Чтобы установить несколько адресов, разделяйте их с помощью <badge>,</badge>. Каждый раз будет выбран случайный адрес.",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -65,6 +65,7 @@
   "hostsDialog.noise.info": "packet,delay (e.g. rand:10-20,100-200)",
   "hostsDialog.noise.info.attention": "Attention: currently, this feature only supported in streisand >= 1.6.32 and v2rayNG >= 1.8.39 (custom config)",
   "hostsDialog.noise.info.examples": "Examples:",
+  "hostsDialog.xhttpExtra": "xHTTP extra (JSON)",
   "hostsDialog.host": "请求主机",
   "hostsDialog.host.info": "默认情况下，如果在 Xray 配置中设置了请求主机，则使用该主机。但是，如果需要，您可以在此处设置自定义请求主机。",
   "hostsDialog.host.multiHost": "使用 <badge>,</badge> 作为分隔符设置多个地址，使用时，每次随机选择一个地址。",

--- a/app/dashboard/src/components/HostsDialog.tsx
+++ b/app/dashboard/src/components/HostsDialog.tsx
@@ -78,7 +78,18 @@ export const HostsDialog: FC = () => {
 
   useEffect(() => {
     if (hosts && isEditingHosts) {
-      form.reset(hosts);
+      const formHosts = Object.fromEntries(
+        Object.entries(hosts).map(([key, hostList]) => [
+          key,
+          (hostList as any[]).map((host) => ({
+            ...host,
+            xhttp_extra: host.xhttp_extra
+              ? JSON.stringify(host.xhttp_extra, null, 2)
+              : "",
+          })),
+        ])
+      );
+      form.reset(formHosts);
     }
   }, [hosts, isEditingHosts, form]);
 
@@ -89,7 +100,18 @@ export const HostsDialog: FC = () => {
 
   const handleFormSubmit = useCallback(
     (hostsData: z.infer<typeof hostsSchema>) => {
-      setHosts(hostsData)
+      const payload = Object.fromEntries(
+        Object.entries(hostsData).map(([key, hostList]) => [
+          key,
+          (hostList as any[]).map((host) => ({
+            ...host,
+            xhttp_extra: host.xhttp_extra
+              ? JSON.parse(host.xhttp_extra)
+              : null,
+          })),
+        ])
+      );
+      setHosts(payload as z.infer<typeof hostsSchema>)
         .then(() => {
           toast({
             title: t("hostsDialog.savedSuccess"),

--- a/app/dashboard/src/components/hostsDialog/AccordionInboundContent.tsx
+++ b/app/dashboard/src/components/hostsDialog/AccordionInboundContent.tsx
@@ -31,6 +31,7 @@ const EMPTY_HOST = {
   alpn: "",
   fingerprint: "",
   use_sni_as_host: false,
+  xhttp_extra: "",
   bot_usernames: [],
   node_ids: [],
 };

--- a/app/dashboard/src/components/hostsDialog/HostAdvancedOptions.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostAdvancedOptions.tsx
@@ -365,6 +365,16 @@ export const HostAdvancedOptions = memo(
             }}
           />
 
+          {["splithttp", "xhttp"].includes(inbound?.network) && (
+            <RHFInput
+              label={t("hostsDialog.xhttpExtra")}
+              registerProps={register(`${hostKey}.${index}.xhttp_extra`)}
+              error={accordionErrors?.[index]?.xhttp_extra}
+              placeholder='{"xPaddingMethod": "tokenish"}'
+              inputProps={{ size: "sm", borderRadius: "4px" }}
+            />
+          )}
+
           <RHFCheckbox
             label={t("hostsDialog.useSniAsHost")}
             registerProps={register(`${hostKey}.${index}.use_sni_as_host`)}

--- a/app/dashboard/src/components/hostsDialog/schema.tsx
+++ b/app/dashboard/src/components/hostsDialog/schema.tsx
@@ -30,6 +30,26 @@ export const hostsSchema = z.record(
         alpn: z.string(),
         fingerprint: z.string(),
         use_sni_as_host: z.boolean().default(false),
+        xhttp_extra: z
+          .string()
+          .nullable()
+          .optional()
+          .refine(
+            (v) => {
+              if (!v) return true;
+              try {
+                const parsed = JSON.parse(v);
+                return (
+                  typeof parsed === "object" &&
+                  !Array.isArray(parsed) &&
+                  parsed !== null
+                );
+              } catch {
+                return false;
+              }
+            },
+            { message: "Must be a valid JSON object" }
+          ),
         bot_usernames: z.array(z.string()).default([]),
         node_ids: z.array(z.number()).default([]),
       })

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -172,6 +172,7 @@ def add_host(db: Session, inbound_tag: str, host: ProxyHostModify) -> list[Proxy
             security=host.security,
             alpn=host.alpn,
             fingerprint=host.fingerprint,
+            xhttp_extra=host.xhttp_extra,
             bots=bots,
             nodes=nodes,
         )
@@ -213,6 +214,7 @@ def update_hosts(db: Session, inbound_tag: str, modified_hosts: list[ProxyHostMo
             noise_setting=host.noise_setting,
             random_user_agent=host.random_user_agent,
             use_sni_as_host=host.use_sni_as_host,
+            xhttp_extra=host.xhttp_extra,
             bots=_get_bots_by_usernames(db, host.bot_usernames),
             nodes=_get_nodes_by_ids(db, host.node_ids),
         )

--- a/app/db/migrations/versions/e976cad65b63_npvpn_1533_add_xhttp_extra_to_hosts.py
+++ b/app/db/migrations/versions/e976cad65b63_npvpn_1533_add_xhttp_extra_to_hosts.py
@@ -1,0 +1,24 @@
+"""npvpn_1533_add_xhttp_extra_to_hosts
+
+Revision ID: e976cad65b63
+Revises: a7b8c9d0e1f2
+Create Date: 2026-07-08 15:07:58.493451
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e976cad65b63'
+down_revision = 'a7b8c9d0e1f2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("hosts", sa.Column("xhttp_extra", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("hosts", "xhttp_extra")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -380,6 +380,7 @@ class ProxyHost(Base):
     noise_setting = Column(String(2000), nullable=True)
     random_user_agent = Column(Boolean, nullable=False, default=False, server_default="0")
     use_sni_as_host = Column(Boolean, nullable=False, default=False, server_default="0")
+    xhttp_extra = Column(JSON, nullable=True)
     bots = relationship("Bot", secondary=host_bot_association, back_populates="hosts")
 
     @property

--- a/app/models/proxy.py
+++ b/app/models/proxy.py
@@ -157,6 +157,7 @@ class ProxyHost(BaseModel):
     noise_setting: str | None = Field(None, nullable=True)
     random_user_agent: bool | None = None
     use_sni_as_host: bool | None = None
+    xhttp_extra: dict | None = None
     model_config = ConfigDict(from_attributes=True)
 
     @field_validator("remark", mode="after")
@@ -192,6 +193,13 @@ class ProxyHost(BaseModel):
                 raise ValueError("Noise setting must be like this: packet,delay (rand:10-20,100-200).")
             if len(v) > 2000:
                 raise ValueError("Noise can't be longer that 2000 character")
+        return v
+
+    @field_validator("xhttp_extra", check_fields=False)
+    @classmethod
+    def validate_xhttp_extra(cls, v):
+        if v is not None and not isinstance(v, dict):
+            raise ValueError("xhttp_extra must be a JSON object")
         return v
 
 

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -482,6 +482,7 @@ def process_inbounds_and_tags(
                         "fragment_setting": host["fragment_setting"],
                         "noise_setting": host["noise_setting"],
                         "random_user_agent": host["random_user_agent"],
+                        "xhttp_extra": host["xhttp_extra"],
                     }
                 )
 

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -82,6 +82,7 @@ class V2rayShareLink(str):
                 heartbeatPeriod=inbound.get("heartbeatPeriod", 0),
                 keepAlivePeriod=inbound.get("keepAlivePeriod", 0),
                 xmux=inbound.get("xmux", {}),
+                xhttp_extra=inbound.get("xhttp_extra"),
             )
 
         elif inbound["protocol"] == "vless":
@@ -114,6 +115,7 @@ class V2rayShareLink(str):
                 heartbeatPeriod=inbound.get("heartbeatPeriod", 0),
                 keepAlivePeriod=inbound.get("keepAlivePeriod", 0),
                 xmux=inbound.get("xmux", {}),
+                xhttp_extra=inbound.get("xhttp_extra"),
             )
 
         elif inbound["protocol"] == "trojan":
@@ -146,6 +148,7 @@ class V2rayShareLink(str):
                 heartbeatPeriod=inbound.get("heartbeatPeriod", 0),
                 keepAlivePeriod=inbound.get("keepAlivePeriod", 0),
                 xmux=inbound.get("xmux", {}),
+                xhttp_extra=inbound.get("xhttp_extra"),
             )
 
         elif inbound["protocol"] == "shadowsocks":
@@ -191,6 +194,7 @@ class V2rayShareLink(str):
         heartbeatPeriod: int = 0,
         keepAlivePeriod: int = 0,
         xmux: dict = {},
+        xhttp_extra: dict | None = None,
     ):
         payload = {
             "add": address,
@@ -235,18 +239,21 @@ class V2rayShareLink(str):
                 payload["mode"] = "gun"
 
         elif net in ("splithttp", "xhttp"):
-            extra = {
-                "scMaxEachPostBytes": sc_max_each_post_bytes,
-                "scMaxConcurrentPosts": sc_max_concurrent_posts,
-                "scMinPostsIntervalMs": sc_min_posts_interval_ms,
-                "xPaddingBytes": x_padding_bytes,
-                "noGRPCHeader": noGRPCHeader,
-            }
-            if xmux:
-                extra["xmux"] = xmux
+            if xhttp_extra:
+                extra = copy.deepcopy(xhttp_extra)
+            else:
+                extra = {
+                    "scMaxEachPostBytes": sc_max_each_post_bytes,
+                    "scMaxConcurrentPosts": sc_max_concurrent_posts,
+                    "scMinPostsIntervalMs": sc_min_posts_interval_ms,
+                    "xPaddingBytes": x_padding_bytes,
+                    "noGRPCHeader": noGRPCHeader,
+                }
+                if xmux:
+                    extra["xmux"] = xmux
+                if keepAlivePeriod > 0:
+                    extra["keepAlivePeriod"] = keepAlivePeriod
             payload["type"] = mode
-            if keepAlivePeriod > 0:
-                extra["keepAlivePeriod"] = keepAlivePeriod
             payload["extra"] = extra
 
         elif net == "ws":
@@ -286,6 +293,7 @@ class V2rayShareLink(str):
         heartbeatPeriod: int = 0,
         keepAlivePeriod: int = 0,
         xmux: dict = {},
+        xhttp_extra: dict | None = None,
     ):
 
         payload = {"security": tls, "type": net, "headerType": type}
@@ -308,17 +316,20 @@ class V2rayShareLink(str):
             payload["path"] = path
             payload["host"] = host
             payload["mode"] = mode
-            extra = {
-                "scMaxEachPostBytes": sc_max_each_post_bytes,
-                "scMaxConcurrentPosts": sc_max_concurrent_posts,
-                "scMinPostsIntervalMs": sc_min_posts_interval_ms,
-                "xPaddingBytes": x_padding_bytes,
-                "noGRPCHeader": noGRPCHeader,
-            }
-            if keepAlivePeriod > 0:
-                extra["keepAlivePeriod"] = keepAlivePeriod
-            if xmux:
-                extra["xmux"] = xmux
+            if xhttp_extra:
+                extra = copy.deepcopy(xhttp_extra)
+            else:
+                extra = {
+                    "scMaxEachPostBytes": sc_max_each_post_bytes,
+                    "scMaxConcurrentPosts": sc_max_concurrent_posts,
+                    "scMinPostsIntervalMs": sc_min_posts_interval_ms,
+                    "xPaddingBytes": x_padding_bytes,
+                    "noGRPCHeader": noGRPCHeader,
+                }
+                if keepAlivePeriod > 0:
+                    extra["keepAlivePeriod"] = keepAlivePeriod
+                if xmux:
+                    extra["xmux"] = xmux
             payload["extra"] = json.dumps(extra, separators=(",", ":"))
 
         elif net == "kcp":
@@ -386,6 +397,7 @@ class V2rayShareLink(str):
         heartbeatPeriod: int = 0,
         keepAlivePeriod: int = 0,
         xmux: dict = {},
+        xhttp_extra: dict | None = None,
     ):
 
         payload = {"security": tls, "type": net, "headerType": type}
@@ -404,17 +416,20 @@ class V2rayShareLink(str):
             payload["path"] = path
             payload["host"] = host
             payload["mode"] = mode
-            extra = {
-                "scMaxEachPostBytes": sc_max_each_post_bytes,
-                "scMaxConcurrentPosts": sc_max_concurrent_posts,
-                "scMinPostsIntervalMs": sc_min_posts_interval_ms,
-                "xPaddingBytes": x_padding_bytes,
-                "noGRPCHeader": noGRPCHeader,
-            }
-            if keepAlivePeriod > 0:
-                extra["keepAlivePeriod"] = keepAlivePeriod
-            if xmux:
-                extra["xmux"] = xmux
+            if xhttp_extra:
+                extra = copy.deepcopy(xhttp_extra)
+            else:
+                extra = {
+                    "scMaxEachPostBytes": sc_max_each_post_bytes,
+                    "scMaxConcurrentPosts": sc_max_concurrent_posts,
+                    "scMinPostsIntervalMs": sc_min_posts_interval_ms,
+                    "xPaddingBytes": x_padding_bytes,
+                    "noGRPCHeader": noGRPCHeader,
+                }
+                if keepAlivePeriod > 0:
+                    extra["keepAlivePeriod"] = keepAlivePeriod
+                if xmux:
+                    extra["xmux"] = xmux
             payload["extra"] = json.dumps(extra, separators=(",", ":"))
 
         elif net == "quic":

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -634,6 +634,7 @@ class V2rayJsonConfig(str):
         mode: str = "auto",
         noGRPCHeader: bool = False,
         keepAlivePeriod: int = 0,
+        xhttp_extra: dict | None = None,
     ) -> dict:
         config = copy.deepcopy(self.settings.get("splithttpSettings", {}))
 
@@ -644,15 +645,21 @@ class V2rayJsonConfig(str):
             config["host"] = host
         if random_user_agent:
             config["headers"]["User-Agent"] = choice(self.user_agent_list)
-        config.setdefault("scMaxEachPostBytes", sc_max_each_post_bytes)
-        config.setdefault("scMaxConcurrentPosts", sc_max_concurrent_posts)
-        config.setdefault("scMinPostsIntervalMs", sc_min_posts_interval_ms)
-        config.setdefault("xPaddingBytes", x_padding_bytes)
-        config["noGRPCHeader"] = noGRPCHeader
-        if xmux:
-            config["xmux"] = xmux
-        if keepAlivePeriod > 0:
-            config["keepAlivePeriod"] = keepAlivePeriod
+
+        if xhttp_extra:
+            config["extra"] = copy.deepcopy(xhttp_extra)
+        else:
+            extra = copy.deepcopy(config.get("extra", {}))
+            extra.setdefault("scMaxEachPostBytes", sc_max_each_post_bytes)
+            extra.setdefault("scMaxConcurrentPosts", sc_max_concurrent_posts)
+            extra.setdefault("scMinPostsIntervalMs", sc_min_posts_interval_ms)
+            extra.setdefault("xPaddingBytes", x_padding_bytes)
+            extra["noGRPCHeader"] = noGRPCHeader
+            if xmux:
+                extra["xmux"] = xmux
+            if keepAlivePeriod > 0:
+                extra["keepAlivePeriod"] = keepAlivePeriod
+            config["extra"] = extra
         # core will ignore unknown variables
 
         return config
@@ -937,6 +944,7 @@ class V2rayJsonConfig(str):
         noGRPCHeader: bool = False,
         heartbeatPeriod: int = 0,
         keepAlivePeriod: int = 0,
+        xhttp_extra: dict | None = None,
     ) -> dict:
 
         if net == "ws":
@@ -972,6 +980,7 @@ class V2rayJsonConfig(str):
                 mode=mode,
                 noGRPCHeader=noGRPCHeader,
                 keepAlivePeriod=keepAlivePeriod,
+                xhttp_extra=xhttp_extra,
             )
         else:
             network_setting = {}
@@ -1054,6 +1063,7 @@ class V2rayJsonConfig(str):
             noGRPCHeader=inbound.get("noGRPCHeader", False),
             heartbeatPeriod=inbound.get("heartbeatPeriod", 0),
             keepAlivePeriod=inbound.get("keepAlivePeriod", 0),
+            xhttp_extra=inbound.get("xhttp_extra"),
         )
 
         if inbound.get("mux_enable", False):

--- a/app/xray/__init__.py
+++ b/app/xray/__init__.py
@@ -64,6 +64,7 @@ def hosts(storage: dict):
                     "random_user_agent": host.random_user_agent,
                     "use_sni_as_host": host.use_sni_as_host,
                     "bot_usernames": host.bot_usernames,
+                    "xhttp_extra": host.xhttp_extra,
                 }
                 for host in inbound_hosts
                 if not host.is_disabled

--- a/tests/test_host_xhttp_extra.py
+++ b/tests/test_host_xhttp_extra.py
@@ -1,0 +1,42 @@
+"""NPVPN-1533: xhttp_extra на хосте — валидация JSON-объекта."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# app.models.proxy тянет app.utils.system (random_password), а тот на импорте
+# делает `from app import scheduler` — при заглушенном пакете app (см. conftest)
+# это падает ImportError. Заглушаем app.utils.system минимальной реализацией:
+# в тестируемом пути (валидация xhttp_extra) random_password не вызывается.
+if "app.utils.system" not in sys.modules:
+    _system_stub = types.ModuleType("app.utils.system")
+    _system_stub.random_password = lambda *a, **kw: "stub"
+    sys.modules["app.utils.system"] = _system_stub
+
+from app.models.proxy import ProxyHost
+
+
+def _host(**kw):
+    return ProxyHost(remark="r", address="a", **kw)
+
+
+def test_xhttp_extra_accepts_dict():
+    h = _host(xhttp_extra={"xPaddingMethod": "tokenish"})
+    assert h.xhttp_extra == {"xPaddingMethod": "tokenish"}
+
+
+def test_xhttp_extra_accepts_none():
+    assert _host().xhttp_extra is None
+
+
+def test_xhttp_extra_rejects_list():
+    with pytest.raises(ValueError):
+        _host(xhttp_extra=["not", "an", "object"])
+
+
+def test_xhttp_extra_rejects_scalar():
+    with pytest.raises(ValueError):
+        _host(xhttp_extra="oops")

--- a/tests/test_v2ray_extra.py
+++ b/tests/test_v2ray_extra.py
@@ -144,3 +144,29 @@ def test_vless_xhttp_extra_empty_keeps_defaults():
     )
     extra = json.loads(_extra_from_link(link))
     assert "scMaxEachPostBytes" in extra  # прежняя дефолтная сборка не сломана
+
+
+from app.subscription.v2ray import V2rayJsonConfig  # noqa: E402
+
+
+def _splithttp(**kwargs):
+    # Обходим тяжёлый __init__: собираем ровно то, что нужно splithttp_config.
+    cfg = V2rayJsonConfig.__new__(V2rayJsonConfig)
+    cfg.settings = {}
+    cfg.user_agent_list = []
+    return cfg.splithttp_config(**kwargs)
+
+
+def test_splithttp_defaults_go_into_nested_extra():
+    cfg = _splithttp(path="/p", host="h.com")
+    assert "extra" in cfg
+    assert cfg["extra"]["scMaxEachPostBytes"] == 1000000
+    assert cfg["extra"]["xPaddingBytes"] == "100-1000"
+    # ключи больше не лежат в корне splithttpSettings
+    assert "scMaxEachPostBytes" not in cfg
+
+
+def test_splithttp_xhttp_extra_full_replace():
+    custom = {"xPaddingMethod": "tokenish", "seqKey": "chunk_id"}
+    cfg = _splithttp(path="/p", host="h.com", xhttp_extra=custom)
+    assert cfg["extra"] == custom

--- a/tests/test_v2ray_extra.py
+++ b/tests/test_v2ray_extra.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import base64  # noqa: E402
 import json
 import sys
 import types
@@ -81,3 +82,65 @@ def test_trojan_xhttp_extra_is_compact():
     extra = _extra_from_link(link)
     assert " " not in extra
     json.loads(extra)
+
+
+def _vmess_payload(link: str) -> dict:
+    raw = link[len("vmess://") :]
+    return json.loads(base64.b64decode(raw).decode())
+
+
+def test_vless_xhttp_extra_full_replace():
+    custom = {"xPaddingMethod": "tokenish", "seqKey": "chunk_id"}
+    link = V2rayShareLink.vless(
+        remark="t",
+        address="e.com",
+        port=443,
+        id="00000000-0000-0000-0000-000000000000",
+        net="xhttp",
+        tls="tls",
+        xhttp_extra=custom,
+    )
+    extra = json.loads(_extra_from_link(link))
+    assert extra == custom  # только заданные ключи, без дефолтных 5
+
+
+def test_trojan_xhttp_extra_full_replace():
+    custom = {"xPaddingMethod": "tokenish"}
+    link = V2rayShareLink.trojan(
+        remark="t",
+        address="e.com",
+        port=443,
+        password="p",
+        net="xhttp",
+        tls="tls",
+        xhttp_extra=custom,
+    )
+    assert json.loads(_extra_from_link(link)) == custom
+
+
+def test_vmess_xhttp_extra_full_replace():
+    custom = {"xPaddingMethod": "tokenish", "noGRPCHeader": True}
+    link = V2rayShareLink.vmess(
+        remark="t",
+        address="e.com",
+        port=443,
+        id="00000000-0000-0000-0000-000000000000",
+        net="xhttp",
+        tls="tls",
+        xhttp_extra=custom,
+    )
+    assert _vmess_payload(link)["extra"] == custom
+
+
+def test_vless_xhttp_extra_empty_keeps_defaults():
+    link = V2rayShareLink.vless(
+        remark="t",
+        address="e.com",
+        port=443,
+        id="00000000-0000-0000-0000-000000000000",
+        net="xhttp",
+        tls="tls",
+        xhttp_extra=None,
+    )
+    extra = json.loads(_extra_from_link(link))
+    assert "scMaxEachPostBytes" in extra  # прежняя дефолтная сборка не сломана


### PR DESCRIPTION
## Что и зачем

Раньше блок `extra` для сетей `xhttp`/`splithttp` собирался вручную из жёстко прописанного списка из 5 ключей (`scMaxEachPostBytes`, `scMaxConcurrentPosts`, `scMinPostsIntervalMs`, `xPaddingBytes`, `noGRPCHeader`). Любые другие поля (`xPaddingMethod`, `seqKey`, `sessionKey` и т.п.) терялись, а задать их можно было только глобально через `settings.json` — сразу для всех xhttp-хостов.

Теперь у хоста есть поле `xhttp_extra` (JSON). Если оно задано — объект целиком (**полная замена**, 1:1) уходит клиенту в `extra`, и в share-ссылки, и в JSON-подписку. Разным хостам можно слать разный набор.

Заодно устранено расхождение форматов: в JSON-подписке ключи `extra` теперь кладутся во **вложенный** `splithttpSettings.extra` (как ожидает xray), а не в корень.

## Изменения

- **БД/модель:** колонка `hosts.xhttp_extra` (JSON, nullable) + миграция `e976cad65b63`.
- **API:** поле `xhttp_extra: dict | None` в pydantic-`ProxyHost` + валидатор «JSON-объект»; проброс в `crud` (`update_hosts`/`add_host`).
- **Генерация:** `V2rayShareLink.vmess/vless/trojan` и `V2rayJsonConfig.splithttp_config` — полная замена `extra` при заданном `xhttp_extra`, иначе прежняя сборка. Компактная сериализация vless/trojan (`separators=(",",":")`) сохранена (регрессия NPVPN-1583).
- **Проброс:** `xray.hosts()` → `share.process_inbounds_and_tags` → генератор.
- **Дашборд:** textarea «xHTTP extra (JSON)» в доп. опциях хоста — **только для xhttp/splithttp-инбаундов**; zod-валидация JSON-объекта; round-trip форма↔API; i18n во всех локалях.

## Тесты

`tests/test_v2ray_extra.py` (share + JSON), `tests/test_host_xhttp_extra.py` (валидатор). Полный набор панели: **126 passed, 3 skipped**. Сборка дашборда (`tsc && vite build`) — чисто.

## ⚠️ Перед мержем — стенд-smoke

JSON-унификация (top-level ключи → вложенный `extra`) — это поведенческое изменение и для хостов **без** `xhttp_extra`. Нужно на стенде:
1. Применить миграцию на копии MySQL (`nvb_mysql`).
2. На живом xhttp-хосте проверить: (a) share `extra` = ровно заданный объект при set; (b) JSON `splithttpSettings.extra` = ровно заданный объект при set; (c) хосты **без** `xhttp_extra` по-прежнему принимаются клиентом (Happ) с ключами теперь во вложенном `extra`.

## Мерж

Squash and merge (линейная история).
