### PR TITLE
NPVPN-1650/disable ads

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -335,6 +335,8 @@
   "botSettings.subProfileTitleHint": "Profile title shown in subscription clients.",
   "botSettings.botUrlHint": "Bot URL for announce-url and fallback pages, e.g. https://t.me/my_vpn_bot.",
   "botSettings.webUrlHint": "Web cabinet URL for the subscription page button. Synced from telegram bot (web_frontend.domain).",
+  "botSettings.showAds": "Show platform link",
+  "botSettings.showAdsHint": "Shows “Powered by npvpn” on expired, revoked, and device-limited subscription pages.",
   "botSettings.subProfileUrlHint": "Subscription profile page URL. Leave empty for auto fallback.",
   "botSettings.serverTextHint": "One message per line or separated by commas.",
   "botSettings.subUpdateIntervalHint": "Number in hours, e.g. 12.",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -291,6 +291,8 @@
   "botSettings.subUnsupportedClientServerText": "متن سرور کلاینت پشتیبانی‌نشده",
   "botSettings.subUpdateInterval": "بازه به‌روزرسانی پروفایل",
   "botSettings.webUrlHint": "آدرس وب‌کابین برای دکمه صفحه اشتراک. از ربات تلگرام همگام‌سازی می‌شود (web_frontend.domain).",
+  "botSettings.showAds": "نمایش لینک پلتفرم",
+  "botSettings.showAdsHint": "نمایش «سایت روی پلتفرم npvpn کار می‌کند» در صفحات اشتراک منقضی، لغوشده یا محدود.",
   "botSettings.tabBotInfo": "اطلاعات ربات",
   "botSettings.tabSubscription": "اشتراک",
   "botSettings.tabMessages": "پیام‌ها",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -336,6 +336,8 @@
   "botSettings.subProfileTitleHint": "Заголовок профиля подписки, который увидит клиент.",
   "botSettings.botUrlHint": "Ссылка на бота для announce-url и fallback-страниц, например https://t.me/my_vpn_bot.",
   "botSettings.webUrlHint": "URL веб-кабинета для кнопки на странице подписки. Синхронизируется из telegram-бота (web_frontend.domain).",
+  "botSettings.showAds": "Показывать ссылку на платформу",
+  "botSettings.showAdsHint": "Строка «Сайт работает на платформе npvpn» на страницах истекшей, отозванной или лимитированной подписки.",
   "botSettings.subProfileUrlHint": "URL страницы профиля подписки. Можно оставить пустым для автоподстановки.",
   "botSettings.serverTextHint": "По одному сообщению на строку или через запятую.",
   "botSettings.subUpdateIntervalHint": "Число в часах, например 12.",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -287,6 +287,8 @@
   "botSettings.subUnsupportedClientServerText": "不支持客户端服务器文本",
   "botSettings.subUpdateInterval": "配置更新间隔",
   "botSettings.webUrlHint": "订阅页按钮指向的 Web 控制台 URL。从 Telegram 机器人同步（web_frontend.domain）。",
+  "botSettings.showAds": "显示平台链接",
+  "botSettings.showAdsHint": "在过期、吊销或设备受限的订阅页面显示“由 npvpn 提供支持”。",
   "botSettings.tabBotInfo": "基本信息",
   "botSettings.tabSubscription": "订阅设置",
   "botSettings.tabMessages": "消息",

--- a/app/dashboard/src/components/BotSettingsDialog.tsx
+++ b/app/dashboard/src/components/BotSettingsDialog.tsx
@@ -81,6 +81,7 @@ const emptySettings: BotSettings = {
   sub_custom_headers: "",
   bs_monthly_limit: 0,
   bs_extra_reset_pool_on_prolong: false,
+  show_ads: true,
 };
 
 type ServerTextField =
@@ -339,6 +340,7 @@ export const BotSettingsDialog: FC = () => {
       sub_custom_headers: current.sub_custom_headers,
       bs_monthly_limit: current.bs_monthly_limit,
       bs_extra_reset_pool_on_prolong: current.bs_extra_reset_pool_on_prolong,
+      show_ads: current.show_ads,
     };
   };
 
@@ -740,6 +742,20 @@ export const BotSettingsDialog: FC = () => {
                       </FormHelperText>
                     </FormControl>
                   </SimpleGrid>
+
+                  <FormControl>
+                    <FormLabel>{t("botSettings.showAds")}</FormLabel>
+                    <Switch
+                      colorScheme="primary"
+                      isChecked={settings.show_ads}
+                      onChange={(e) =>
+                        updateSettings({ show_ads: e.target.checked })
+                      }
+                    />
+                    <FormHelperText>
+                      {t("botSettings.showAdsHint")}
+                    </FormHelperText>
+                  </FormControl>
                 </VStack>
               </TabPanel>
 

--- a/app/dashboard/src/components/Footer.tsx
+++ b/app/dashboard/src/components/Footer.tsx
@@ -1,10 +1,8 @@
 import { BoxProps, HStack, Link, Text } from "@chakra-ui/react";
 import { ORGANIZATION_URL, REPO_URL } from "constants/Project";
-import { useDashboard } from "contexts/DashboardContext";
 import { FC } from "react";
 
 export const Footer: FC<BoxProps> = (props) => {
-  const { version } = useDashboard();
   return (
     <HStack w="full" py="0" position="relative" {...props}>
       <Text
@@ -17,10 +15,9 @@ export const Footer: FC<BoxProps> = (props) => {
         <Link color="blue.400" href={REPO_URL}>
           Marzban
         </Link>
-        {version ? ` (v${version}), ` : ", "}
-        Made with ❤️ in{" "}
+        , Made by{" "}
         <Link color="blue.400" href={ORGANIZATION_URL}>
-          Gozargah
+          npvpn
         </Link>
       </Text>
     </HStack>

--- a/app/dashboard/src/components/Header.tsx
+++ b/app/dashboard/src/components/Header.tsx
@@ -24,7 +24,7 @@ import {
   SunIcon,
   WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline";
-import { DONATION_URL, REPO_URL } from "constants/Project";
+import { REPO_URL } from "constants/Project";
 import { useDashboard } from "contexts/DashboardContext";
 import differenceInDays from "date-fns/differenceInDays";
 import isValid from "date-fns/isValid";
@@ -199,20 +199,6 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                   </MenuItem>
                 </>
               )}
-              <Link to={DONATION_URL} target="_blank">
-                <MenuItem
-                  maxW="170px"
-                  fontSize="sm"
-                  icon={<DonationIcon />}
-                  position="relative"
-                  onClick={handleOnClose}
-                >
-                  {t("header.donation")}{" "}
-                  {showDonationNotif && (
-                    <NotificationCircle top="3" right="2" />
-                  )}
-                </MenuItem>
-              </Link>
               <Link to="/login">
                 <MenuItem maxW="170px" fontSize="sm" icon={<LogoutIcon />}>
                   {t("header.logout")}

--- a/app/dashboard/src/constants/Project.ts
+++ b/app/dashboard/src/constants/Project.ts
@@ -1,3 +1,2 @@
-export const REPO_URL = "https://github.com/Gozargah/Marzban";
-export const ORGANIZATION_URL = "https://github.com/Gozargah";
-export const DONATION_URL = "https://github.com/Gozargah/Marzban#donation";
+export const REPO_URL = "https://github.com/npvpn/panel";
+export const ORGANIZATION_URL = "https://github.com/npvpn";

--- a/app/dashboard/src/types/Bot.ts
+++ b/app/dashboard/src/types/Bot.ts
@@ -31,5 +31,6 @@ export type BotSettings = {
   sub_custom_headers: string;
   bs_monthly_limit: number;
   bs_extra_reset_pool_on_prolong: boolean;
+  show_ads: boolean;
   updated_at?: string;
 };

--- a/app/models/bot.py
+++ b/app/models/bot.py
@@ -61,6 +61,7 @@ DEFAULT_BOT_SETTINGS: dict[str, Any] = {
     "sub_routing_json_default": "",
     "sub_routing_json_bs": "",
     "sub_custom_headers": "",
+    "show_ads": True,
 }
 
 
@@ -121,6 +122,7 @@ class BotSettingsPayload(BaseModel):
     sub_routing_json_default: str = ""
     sub_routing_json_bs: str = ""
     sub_custom_headers: str = ""
+    show_ads: bool = True
 
     @field_validator(
         "sub_revoked_server_text",
@@ -187,5 +189,6 @@ def apply_bot_settings_fallback(raw_settings: dict[str, Any] | None) -> dict[str
 
     base["sub_device_limit_hard_mode"] = bool(base.get("sub_device_limit_hard_mode"))
     base["bs_extra_reset_pool_on_prolong"] = bool(base.get("bs_extra_reset_pool_on_prolong", False))
+    base["show_ads"] = bool(base.get("show_ads", True))
 
     return base

--- a/app/subscription/page.py
+++ b/app/subscription/page.py
@@ -21,5 +21,6 @@ def build_subscription_page_context(db: Session, dbuser, token: str) -> dict:
         "sub_path": XRAY_SUBSCRIPTION_PATH,
         "web_url": (bot_settings.get("web_url") or "").strip(),
         "bot_url": bot_settings["bot_url"],
+        "show_ads": bool(bot_settings.get("show_ads", True)),
         "client_apps": build_client_apps_view(crud.get_global_setting(db, CLIENT_APPS_KEY)),
     }

--- a/templates/sub/expired.html
+++ b/templates/sub/expired.html
@@ -145,12 +145,14 @@
         {% endif %}
       </div>
 
+      {% if show_ads %}
       <footer class="footer">
         Сайт работает на платформе 
         <a href="https://www.npvpn.net/" class="footer-link" target="_blank" rel="noopener noreferrer" style="text-decoration: none;">
           npvpn
         </a>
       </footer>
+      {% endif %}
     </div>
   </body>
 </html>

--- a/templates/sub/limited.html
+++ b/templates/sub/limited.html
@@ -345,12 +345,14 @@
             Перейти в личный кабинет
           </button>
         {% endif %}
+          {% if show_ads %}
           <p>
             Сайт работает на платформе
             <a href="https://www.npvpn.net/" class="footer-link" target="_blank" rel="noopener noreferrer">
               npvpn
             </a>
           </p>
+          {% endif %}
       </footer>
     </div>
   </body>

--- a/templates/sub/revoked.html
+++ b/templates/sub/revoked.html
@@ -140,12 +140,14 @@
         {% endif %}
       </div>  
 
+      {% if show_ads %}
       <footer class="footer">
         Сайт работает на платформе
         <a href="https://www.npvpn.net/" class="footer-link" target="_blank" rel="noopener noreferrer">
           npvpn
         </a>
       </footer>
+      {% endif %}
     </div>
   </body>
 </html>


### PR DESCRIPTION
NPVPN-1650: настройка show_ads для футера на страницах подписки

## Что и зачем
На страницах expired/limited/revoked всегда показывалась строка «Сайт работает на платформе npvpn». Нужна пер-бот настройка, чтобы эту рекламную ссылку можно было отключить из панели.

## Изменения
- поле `show_ads` (по умолчанию `true`) в настройках бота и fallback
- передача `show_ads` в контекст HTML-страниц подписки
- условный вывод футера npvpn в `expired` / `limited` / `revoked`
- рычажок во вкладке «Основное» диалога настроек бота + локали
- были заменены ссылки оригинального репозитория на репозиторий npvpn
- убрана кнопка "Пожертвования"

## Заметки для ревью
- миграция БД не нужна: ключ в JSON `bot_settings.data`
- для существующих ботов без ключа поведение как раньше (футер виден)
- на `limited` скрывается только строка npvpn, кнопка кабинета остаётся