### PR TITLE
NPVPN-1643: лёгкий эндпоинт GET /api/users/digest для сверки с ботом

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -354,6 +354,17 @@ class UsersResponse(BaseModel):
     total: int
 
 
+class UserDigestEntry(BaseModel):
+    username: str
+    status: str
+    expire: int | None = None
+
+
+class UsersDigestResponse(BaseModel):
+    users: list[UserDigestEntry]
+    total: int
+
+
 class UserDeviceBase(BaseModel):
     hwid: str
     device_os: str | None = None

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -33,6 +33,7 @@ from app.models.user import (
     UserDeviceUpdate,
     UserModify,
     UserResponse,
+    UsersDigestResponse,
     UsersResponse,
     UserStatus,
     UsersUsagesResponse,
@@ -496,6 +497,31 @@ def get_users(
     for u in users:
         crud.ensure_subscription_token(db, u)
     return {"users": users, "total": count}
+
+
+@router.get(
+    "/users/digest",
+    response_model=UsersDigestResponse,
+    responses={403: responses._403},
+)
+def get_users_digest_endpoint(
+    offset: int = None,
+    limit: int = None,
+    bot_username: str | None = None,
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.get_current),
+):
+    """Лёгкий срез {username, status, expire} для сверки с ботом (NPVPN-1643)."""
+    from app.services.user_digest import get_users_digest
+
+    users, total = get_users_digest(
+        db,
+        admins=None if admin.is_sudo else [admin.username],
+        bot_username=bot_username,
+        offset=offset,
+        limit=limit,
+    )
+    return {"users": users, "total": total}
 
 
 @router.post("/users/reset", responses={403: responses._403, 404: responses._404})

--- a/app/services/user_digest.py
+++ b/app/services/user_digest.py
@@ -1,0 +1,46 @@
+"""Лёгкий срез состояния юзеров для сверки с ботом (NPVPN-1643).
+
+Только три колонки, никаких ORM-объектов, ссылок и ensure_subscription_token:
+эндпоинт вызывается по всей базе (десятки тысяч строк) и не должен ни писать
+в БД, ни грузить прокси с инбаундами.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db.crud import _normalize_bot_username
+from app.db.models import Admin, Bot, User
+
+
+def get_users_digest(
+    db: Session,
+    *,
+    admins: list[str] | None = None,
+    bot_username: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+) -> tuple[list[dict], int]:
+    """Возвращает (список из {username, status, expire}, общее количество)."""
+    query = db.query(User.username, User.status, User.expire)
+
+    if bot_username:
+        normalized = _normalize_bot_username(bot_username)
+        if normalized:
+            query = query.join(User.bot).filter(Bot.username == normalized)
+
+    if admins:
+        query = query.join(User.admin).filter(Admin.username.in_(admins))
+
+    total = query.count()
+
+    query = query.order_by(User.id)
+    if offset is not None:
+        query = query.offset(offset)
+    if limit is not None:
+        query = query.limit(limit)
+
+    users = [
+        {"username": username, "status": str(status), "expire": expire} for username, status, expire in query.all()
+    ]
+    return users, total

--- a/app/services/user_digest.py
+++ b/app/services/user_digest.py
@@ -41,6 +41,7 @@ def get_users_digest(
         query = query.limit(limit)
 
     users = [
-        {"username": username, "status": str(status), "expire": expire} for username, status, expire in query.all()
+        {"username": username, "status": getattr(status, "value", status), "expire": expire}
+        for username, status, expire in query.all()
     ]
     return users, total

--- a/tests/test_user_digest.py
+++ b/tests/test_user_digest.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from app.models.user import UserStatus
 from app.services.user_digest import get_users_digest
 
 
@@ -51,7 +52,7 @@ class _FakeDb:
 
 
 def test_returns_three_fields_and_total():
-    db = _FakeDb([("530399467_123", "active", 1767225600)])
+    db = _FakeDb([("530399467_123", UserStatus.active, 1767225600)])
     users, total = get_users_digest(db, admins=None, bot_username=None, offset=None, limit=None)
     assert users == [{"username": "530399467_123", "status": "active", "expire": 1767225600}]
     assert total == 1
@@ -72,6 +73,6 @@ def test_pagination_is_passed_through():
 
 
 def test_null_expire_is_preserved():
-    db = _FakeDb([("530399467_123", "active", None)])
+    db = _FakeDb([("530399467_123", UserStatus.active, None)])
     users, _ = get_users_digest(db, admins=None, bot_username=None, offset=None, limit=None)
     assert users[0]["expire"] is None

--- a/tests/test_user_digest.py
+++ b/tests/test_user_digest.py
@@ -1,0 +1,77 @@
+"""Лёгкий срез юзеров для сверки с ботом (NPVPN-1643).
+
+Существующий GET /api/users не годится: он вызывает ensure_subscription_token
+на каждого юзера, то есть пишет в БД на чтении. Этот сервис читает три
+колонки и ничего не пишет.
+"""
+
+from __future__ import annotations
+
+from app.services.user_digest import get_users_digest
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+        self.offset_applied = None
+        self.limit_applied = None
+
+    def join(self, *_args, **_kwargs):
+        return self
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def offset(self, value):
+        self.offset_applied = value
+        return self
+
+    def limit(self, value):
+        self.limit_applied = value
+        return self
+
+    def count(self):
+        return len(self._rows)
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeDb:
+    def __init__(self, rows):
+        self.last_query = _FakeQuery(rows)
+        self.query_args = None
+
+    def query(self, *args):
+        self.query_args = args
+        return self.last_query
+
+
+def test_returns_three_fields_and_total():
+    db = _FakeDb([("530399467_123", "active", 1767225600)])
+    users, total = get_users_digest(db, admins=None, bot_username=None, offset=None, limit=None)
+    assert users == [{"username": "530399467_123", "status": "active", "expire": 1767225600}]
+    assert total == 1
+
+
+def test_selects_only_three_columns():
+    """Гарантия дешевизны: не грузим ORM-объекты, не тянем прокси и инбаунды."""
+    db = _FakeDb([])
+    get_users_digest(db, admins=None, bot_username=None, offset=None, limit=None)
+    assert len(db.query_args) == 3
+
+
+def test_pagination_is_passed_through():
+    db = _FakeDb([])
+    get_users_digest(db, admins=None, bot_username=None, offset=500, limit=500)
+    assert db.last_query.offset_applied == 500
+    assert db.last_query.limit_applied == 500
+
+
+def test_null_expire_is_preserved():
+    db = _FakeDb([("530399467_123", "active", None)])
+    users, _ = get_users_digest(db, admins=None, bot_username=None, offset=None, limit=None)
+    assert users[0]["expire"] is None


### PR DESCRIPTION
## Что и зачем

Боту нужен дешёвый срез состояния всех пользователей панели, чтобы раз в час сверять свои активные подписки с реальным доступом. Существующий `GET /api/users` для этого не годится: он сериализует полный `UserResponse` с прокси, инбаундами и ссылками, а в цикле по каждому пользователю вызывает `crud.ensure_subscription_token(db, u)`, то есть **пишет в БД на GET-запросе**. Прогон по 27 тысячам пользователей такой ручкой — лишняя запись на каждого и заметная нагрузка на панель.

Парный PR в боте: `npvpn/telegram_bot` — там цикл сверки, снимок расхождений и алерты. Без этого эндпоинта сверка на панели не работает (клиент честно отдаёт исход `unsupported` и пропускает панель), поэтому панель можно катить первой.

## Изменения

- `app/services/user_digest.py` — выборка трёх колонок (`username`, `status`, `expire`) без ORM-объектов, без генерации ссылок и без записи токенов.
- `app/routers/user.py` — тонкая ручка `GET /api/users/digest` с пагинацией и скоупом по админу (sudo видит всех, обычный админ — своих), фильтр по `bot_username`.
- `app/models/user.py` — `UserDigestEntry`, `UsersDigestResponse`.
- `tests/test_user_digest.py` — 4 теста.

## Заметки для ревью

- **`status` отдаётся через `.value`, а не `str()`.** `UserStatus` — это `(str, Enum)`, и `Enum.__str__` перебивает строковый миксин: `str(UserStatus.active)` даёт `"UserStatus.active"`. Первая версия PR содержала эту ошибку — бот сравнивал бы с `"active"` и получал расхождение по всей базе на первом же прогоне. Тесты теперь кладут в подставную сессию настоящий член перечисления, а не строку, иначе регресс снова прошёл бы незамеченным.
- **`order_by(User.id)` обязателен** и стоит до пагинации. Без стабильной сортировки MySQL волен вернуть строки в разном порядке между страницами, и постраничный обход у бота потеряет или продублирует записи — для бота это выглядит как «пользователя нет в панели», то есть как ложное расхождение, запускающее лишнюю синхронизацию.
- `total` считается до `offset`/`limit` — по нему клиент понимает, что обход закончен, и отличает полный срез от оборванного.
- `expire = None` доезжает как `None`, а не как `0`: на стороне бота `None` означает бессрочный доступ и трактуется как расхождение.
- Существующий `GET /api/users` намеренно не тронут. То, что он пишет токены на чтении, — известный долг, вынесен отдельно.
- Миграций и новых зависимостей нет, поведение существующих ручек не меняется.
