### PR TITLE
NPVPN-1504/not found

### DIFF
--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -216,7 +216,7 @@ def user_subscription(
     # 1) Валидация токена и подготовка user/settings.
     dbuser, is_revoked, _ = resolve_subscription_context(token, db)
     if not dbuser:
-        return Response(status_code=404)
+        return handle_not_found(request)
     crud.ensure_subscription_token(db, dbuser)
     is_expired = bool(dbuser.expire and dbuser.expire > 0 and dbuser.expire < int(datetime.now(UTC).timestamp()))
     user: UserResponse = UserResponse.model_validate(dbuser)
@@ -278,7 +278,7 @@ def revoke_subscription_device(
 ):
     dbuser, is_revoked, _ = resolve_subscription_context(token, db)
     if not dbuser:
-        return Response(status_code=404)
+        return handle_not_found(request)
 
     is_expired = bool(dbuser.expire and dbuser.expire > 0 and dbuser.expire < int(datetime.now(UTC).timestamp()))
     if is_revoked or is_expired:
@@ -331,7 +331,7 @@ def user_subscription_with_client_type(
     # рендера выбирается не по UA, а по параметру пути.
     dbuser, is_revoked, _ = resolve_subscription_context(token, db)
     if not dbuser:
-        return Response(status_code=404)
+        return handle_not_found(request)
     crud.ensure_subscription_token(db, dbuser)
     is_expired = bool(dbuser.expire and dbuser.expire > 0 and dbuser.expire < int(datetime.now(UTC).timestamp()))
     user: UserResponse = UserResponse.model_validate(dbuser)
@@ -362,3 +362,10 @@ def user_subscription_with_client_type(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="Unknown client type") from exc
     return render_subscription(ctx, plan)
+
+def handle_not_found(request: Request) -> Response:
+    """Returns a custom 404 error for browsers or an empty response for APIs."""
+    accept_header = request.headers.get("Accept", "")
+    if "text/html" in accept_header:
+        return HTMLResponse(render_template("sub/not_found.html"), status_code=404)
+    return Response(status_code=404)

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -369,3 +369,4 @@ def handle_not_found(request: Request) -> Response:
     if "text/html" in accept_header:
         return HTMLResponse(render_template("sub/not_found.html"), status_code=404)
     return Response(status_code=404)
+    

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -14,6 +14,7 @@ from app.models.user import SubscriptionUserResponse, UserResponse
 from app.subscription.bot_settings import resolve_bot_settings
 from app.subscription.bs_context_builder import build_bs_context
 from app.subscription.headers import build_content_disposition, get_routing_header
+from app.subscription.not_found import render_not_found
 from app.subscription.page import build_subscription_page_context
 from app.subscription.share import generate_subscription
 from app.subscription.subscription_service import (
@@ -216,7 +217,7 @@ def user_subscription(
     # 1) Валидация токена и подготовка user/settings.
     dbuser, is_revoked, _ = resolve_subscription_context(token, db)
     if not dbuser:
-        return handle_not_found(request)
+        return render_not_found(request, db, token)
     crud.ensure_subscription_token(db, dbuser)
     is_expired = bool(dbuser.expire and dbuser.expire > 0 and dbuser.expire < int(datetime.now(UTC).timestamp()))
     user: UserResponse = UserResponse.model_validate(dbuser)
@@ -278,7 +279,7 @@ def revoke_subscription_device(
 ):
     dbuser, is_revoked, _ = resolve_subscription_context(token, db)
     if not dbuser:
-        return handle_not_found(request)
+        return render_not_found(request, db, token)
 
     is_expired = bool(dbuser.expire and dbuser.expire > 0 and dbuser.expire < int(datetime.now(UTC).timestamp()))
     if is_revoked or is_expired:
@@ -331,7 +332,7 @@ def user_subscription_with_client_type(
     # рендера выбирается не по UA, а по параметру пути.
     dbuser, is_revoked, _ = resolve_subscription_context(token, db)
     if not dbuser:
-        return handle_not_found(request)
+        return render_not_found(request, db, token)
     crud.ensure_subscription_token(db, dbuser)
     is_expired = bool(dbuser.expire and dbuser.expire > 0 and dbuser.expire < int(datetime.now(UTC).timestamp()))
     user: UserResponse = UserResponse.model_validate(dbuser)
@@ -362,11 +363,3 @@ def user_subscription_with_client_type(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="Unknown client type") from exc
     return render_subscription(ctx, plan)
-
-
-def handle_not_found(request: Request) -> Response:
-    """Returns a custom 404 error for browsers or an empty response for APIs."""
-    accept_header = request.headers.get("Accept", "")
-    if "text/html" in accept_header:
-        return HTMLResponse(render_template("sub/not_found.html"), status_code=404)
-    return Response(status_code=404)

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -363,10 +363,10 @@ def user_subscription_with_client_type(
         raise HTTPException(status_code=400, detail="Unknown client type") from exc
     return render_subscription(ctx, plan)
 
+
 def handle_not_found(request: Request) -> Response:
     """Returns a custom 404 error for browsers or an empty response for APIs."""
     accept_header = request.headers.get("Accept", "")
     if "text/html" in accept_header:
         return HTMLResponse(render_template("sub/not_found.html"), status_code=404)
     return Response(status_code=404)
-    

--- a/app/subscription/bot_settings.py
+++ b/app/subscription/bot_settings.py
@@ -1,7 +1,11 @@
-from typing import Any
+from __future__ import annotations
 
-from app.db.models import User
+from typing import TYPE_CHECKING, Any
+
 from app.models.bot import apply_bot_settings_fallback
+
+if TYPE_CHECKING:
+    from app.db.models import User
 
 
 def resolve_bot_settings(user: User) -> dict[str, Any]:

--- a/app/subscription/not_found.py
+++ b/app/subscription/not_found.py
@@ -22,11 +22,12 @@ from fastapi.responses import HTMLResponse
 from app import logger
 from app.db import Session, crud
 from app.models.bot import apply_bot_settings_fallback
-from app.subscription.bot_settings import resolve_bot_settings
 from app.templates import render_template
 from app.utils.jwt import get_subscription_payload
 
 NOT_FOUND_TEMPLATE = "sub/not_found.html"
+
+_ALLOWED_HOME_URL_SCHEMES = ("http://", "https://")
 
 
 def render_not_found(request: Request, db: Session, token: str) -> Response:
@@ -39,28 +40,41 @@ def render_not_found(request: Request, db: Session, token: str) -> Response:
 
 def build_not_found_page_context(db: Session, token: str) -> dict[str, Any]:
     """Контекст jinja-шаблона 404: куда ведёт кнопка и показывать ли футер с рекламой."""
-    settings = _resolve_settings_without_user(db, token)
+    settings = _resolve_bot_settings_for_token(db, token)
     if settings is None:
         return {"home_url": "", "show_ads": True}
     home_url = (settings.get("web_url") or "").strip() or (settings.get("bot_url") or "").strip()
+    if not home_url.lower().startswith(_ALLOWED_HOME_URL_SCHEMES):
+        # Значение приходит из настроек бота, которые пишет sudo-админ; шаблон
+        # подставляет home_url в href без экранирования (autoescape выключен на
+        # уровне общего jinja-Environment) — отсекаем всё, что не http(s)-ссылка.
+        home_url = ""
     return {"home_url": home_url, "show_ads": bool(settings.get("show_ads", True))}
 
 
-def _resolve_settings_without_user(db: Session, token: str) -> dict[str, Any] | None:
+def _resolve_bot_settings_for_token(db: Session, token: str) -> dict[str, Any] | None:
     """Настройки бота, которого удалось определить, или None — если определять нечего."""
     try:
         payload = get_subscription_payload(token)
         if payload:
             dbuser = crud.get_user(db, payload["username"])
             if dbuser is not None:
-                return resolve_bot_settings(dbuser)
+                if dbuser.bot and dbuser.bot.settings:
+                    return apply_bot_settings_fallback(dbuser.bot.settings.data)
+                # У найденного пользователя своего бота нет (например, бот был
+                # удалён и bot_id обнулился) — угадывать чужого бота нельзя,
+                # проваливаемся дальше на ступени 2/3.
 
         bots = crud.get_bots(db)
         if len(bots) <= 1:
             bot = bots[0] if bots else None
             raw = bot.settings.data if bot is not None and bot.settings else None
             return apply_bot_settings_fallback(raw)
+        # Ботов несколько, а точного совпадения нет: угадывать нечего, кнопки
+        # не будет. apply_bot_settings_fallback(None) сюда специально не идёт —
+        # он подставит env BOT_URL, и пользователь уедет в чужого бота.
+        return None
     except Exception:
         # 404 обязана отдаваться всегда: сломанный резолв просто оставляет страницу без кнопки.
         logger.warning("[sub] не удалось определить бота для 404-страницы", exc_info=True)
-    return None
+        return None

--- a/app/subscription/not_found.py
+++ b/app/subscription/not_found.py
@@ -1,0 +1,54 @@
+"""404-страница подписки: резолв ссылки для кнопки «На главную» (NPVPN-1762).
+
+404 отдаётся ровно тогда, когда пользователь не найден, а bot_url/web_url в панели
+живут пер-бот. Поэтому бота ищем в три ступени, от точного к грубому:
+
+1. По токену: он разбирается (подпись валидна) даже когда пользователь уже пересоздан
+   или переименован — тогда запись в базе есть и бот известен точно.
+2. Одноботовая панель: пользователя нет, но и выбирать не из чего. Ноль ботов —
+   классический одиночный Marzban, где ссылка живёт в env.
+3. Мультиботовая панель: угадывать нечего, ссылки нет и кнопки не будет. Через
+   apply_bot_settings_fallback(None) здесь идти НЕЛЬЗЯ — он подставит env BOT_URL,
+   и пользователь уедет в чужого бота.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app import logger
+from app.db import Session, crud
+from app.models.bot import apply_bot_settings_fallback
+from app.subscription.bot_settings import resolve_bot_settings
+from app.utils.jwt import get_subscription_payload
+
+NOT_FOUND_TEMPLATE = "sub/not_found.html"
+
+
+def build_not_found_page_context(db: Session, token: str) -> dict[str, Any]:
+    """Контекст jinja-шаблона 404: куда ведёт кнопка и показывать ли футер с рекламой."""
+    settings = _resolve_settings_without_user(db, token)
+    if settings is None:
+        return {"home_url": "", "show_ads": True}
+    home_url = (settings.get("web_url") or "").strip() or (settings.get("bot_url") or "").strip()
+    return {"home_url": home_url, "show_ads": bool(settings.get("show_ads", True))}
+
+
+def _resolve_settings_without_user(db: Session, token: str) -> dict[str, Any] | None:
+    """Настройки бота, которого удалось определить, или None — если определять нечего."""
+    try:
+        payload = get_subscription_payload(token)
+        if payload:
+            dbuser = crud.get_user(db, payload["username"])
+            if dbuser is not None:
+                return resolve_bot_settings(dbuser)
+
+        bots = crud.get_bots(db)
+        if len(bots) <= 1:
+            bot = bots[0] if bots else None
+            raw = bot.settings.data if bot is not None and bot.settings else None
+            return apply_bot_settings_fallback(raw)
+    except Exception:
+        # 404 обязана отдаваться всегда: сломанный резолв просто оставляет страницу без кнопки.
+        logger.warning("[sub] не удалось определить бота для 404-страницы", exc_info=True)
+    return None

--- a/app/subscription/not_found.py
+++ b/app/subscription/not_found.py
@@ -16,13 +16,25 @@ from __future__ import annotations
 
 from typing import Any
 
+from fastapi import Request, Response
+from fastapi.responses import HTMLResponse
+
 from app import logger
 from app.db import Session, crud
 from app.models.bot import apply_bot_settings_fallback
 from app.subscription.bot_settings import resolve_bot_settings
+from app.templates import render_template
 from app.utils.jwt import get_subscription_payload
 
 NOT_FOUND_TEMPLATE = "sub/not_found.html"
+
+
+def render_not_found(request: Request, db: Session, token: str) -> Response:
+    """404 подписки: браузеру — оформленная страница, VPN-клиентам и API — пустой ответ."""
+    if "text/html" not in request.headers.get("Accept", ""):
+        return Response(status_code=404)
+    context = build_not_found_page_context(db, token)
+    return HTMLResponse(render_template(NOT_FOUND_TEMPLATE, context), status_code=404)
 
 
 def build_not_found_page_context(db: Session, token: str) -> dict[str, Any]:

--- a/templates/sub/not_found.html
+++ b/templates/sub/not_found.html
@@ -19,9 +19,11 @@
             <p class="page-subtitle error-subtitle error-description" style="text-align: center; max-width: 28rem;">
                 Возможно, вы перешли по неверной ссылке или страница была удалена
             </p>
-            <!-- <button href="/" class="dark-btn" style="margin-top: 24px; font-size: 16px;">
+            {% if home_url %}
+            <a href="{{ home_url }}" target="_blank" rel="noopener noreferrer" class="dark-btn" style="margin-top: 24px; font-size: 16px;">
                 На главную
-            </button> -->
+            </a>
+            {% endif %}
         </div>
         {% if show_ads %}
             <footer class="footer_404">
@@ -33,14 +35,6 @@
                 </p>
             </footer>
         {% endif %}
-        <footer class="footer_404">
-                <p style="font-family: var(--font-family); font-size: 14px; color: var(--gray-4);">
-                    Сайт работает на платформе
-                    <a href="https://www.npvpn.net/" class="footer-link" target="_blank" rel="noopener noreferrer">
-                        npvpn
-                    </a>
-                </p>
-            </footer>
     </div>
 </body>
 </html>

--- a/templates/sub/not_found.html
+++ b/templates/sub/not_found.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Страница не найдена</title>
+    <link rel="stylesheet" href="/statics/sub/styles/index.css" />
+    <link rel="stylesheet" href="/statics/sub/styles/components.css" />
+    <link rel="icon" href="data:," />
+</head>
+<body>
+    <div class="error-page">
+        <div class="error-content">
+            <div class="error-code">404</div>
+            <h1 class="error-title" style="margin-top: 0.5rem; margin-bottom: 8px;">
+                Страница не найдена
+            </h1>
+            <p class="page-subtitle error-subtitle error-description" style="text-align: center; max-width: 28rem;">
+                Возможно, вы перешли по неверной ссылке или страница была удалена
+            </p>
+            <button href="/" class="dark-btn" style="margin-top: 24px; font-size: 16px;">
+                На главную
+            </button>
+        </div>
+        {% if show_ads %}
+            <footer class="footer_404">
+                <p style="font-family: var(--font-family); font-size: 14px; color: var(--gray-4);">
+                    Сайт работает на платформе
+                    <a href="https://www.npvpn.net/" class="footer-link" target="_blank" rel="noopener noreferrer">
+                        npvpn
+                    </a>
+                </p>
+            </footer>
+        {% endif %}
+    </div>
+</body>
+</html>

--- a/templates/sub/not_found.html
+++ b/templates/sub/not_found.html
@@ -6,6 +6,7 @@
     <title>Страница не найдена</title>
     <link rel="stylesheet" href="/statics/sub/styles/index.css" />
     <link rel="stylesheet" href="/statics/sub/styles/components.css" />
+    <style>@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap');</style>
     <link rel="icon" href="data:," />
 </head>
 <body>
@@ -18,9 +19,9 @@
             <p class="page-subtitle error-subtitle error-description" style="text-align: center; max-width: 28rem;">
                 Возможно, вы перешли по неверной ссылке или страница была удалена
             </p>
-            <button href="/" class="dark-btn" style="margin-top: 24px; font-size: 16px;">
+            <!-- <button href="/" class="dark-btn" style="margin-top: 24px; font-size: 16px;">
                 На главную
-            </button>
+            </button> -->
         </div>
         {% if show_ads %}
             <footer class="footer_404">
@@ -32,6 +33,14 @@
                 </p>
             </footer>
         {% endif %}
+        <footer class="footer_404">
+                <p style="font-family: var(--font-family); font-size: 14px; color: var(--gray-4);">
+                    Сайт работает на платформе
+                    <a href="https://www.npvpn.net/" class="footer-link" target="_blank" rel="noopener noreferrer">
+                        npvpn
+                    </a>
+                </p>
+            </footer>
     </div>
 </body>
 </html>

--- a/templates/sub/styles/components.css
+++ b/templates/sub/styles/components.css
@@ -835,7 +835,7 @@
 
 .footer_404 {
     padding: 16px;
-    padding-bottom: 40px;
+    padding-bottom: 24px;
     text-align: center;
 }
 

--- a/templates/sub/styles/components.css
+++ b/templates/sub/styles/components.css
@@ -807,16 +807,72 @@
   }
 
 
+/* Страница 404 */
+.error-page {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background: var(--bg);
+}
+
+.error-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    text-align: center;
+}
+
+.error-code {
+    font-size: 120px;
+    line-height: 113%;
+    letter-spacing: -0.04em;
+    font-family: var(--third-family);
+    font-weight: 700;
+}
+
+.footer_404 {
+    padding: 16px;
+    padding-bottom: 40px;
+    text-align: center;
+}
+
+.error-title{
+    font-size: 20px;
+    font-family: var(--third-family);
+    font-weight: 700;
+    line-height: 113%;
+    letter-spacing: -0.04em;
+}
+
+.error-subtitle {
+    font-size: 14px;
+}
+
 @media (min-width: 1024px) {
      .footer-ad-bar {
-      bottom: 0; 
-      padding: 12px 16px 12px; 
+      bottom: 0;
+      padding: 12px 16px 12px;
     }
     .footer-ad-bar .footer-ad-inner {
-      font-size: 14px; 
+      font-size: 14px;
       max-width: 100%;
     }
-    
+
+     .error-code {
+        font-size: 200px;
+    }
+
+    .error-title {
+        font-size: 24px;
+    }
+
+    .error-description {
+        font-size: 16px;
+    }
+
     .card-content {
         padding-bottom: 120px;    
     }

--- a/tests/test_not_found_page.py
+++ b/tests/test_not_found_page.py
@@ -158,3 +158,32 @@ def test_unparsable_token_skips_user_lookup(not_found, monkeypatch):
     ctx = not_found.build_not_found_page_context(db=object(), token="garbage")
 
     assert ctx["home_url"] == "https://t.me/only"
+
+
+def _request(accept: str):
+    """Минимальная замена fastapi.Request: нужен только заголовок Accept."""
+    return SimpleNamespace(headers={"Accept": accept})
+
+
+def test_api_client_gets_empty_404(not_found, monkeypatch):
+    def _must_not_render(name, context=None):
+        raise AssertionError("шаблон не должен рендериться для не-HTML клиента")
+
+    monkeypatch.setattr(not_found, "render_template", _must_not_render)
+
+    response = not_found.render_not_found(_request("*/*"), db=object(), token="whatever-long-token")
+
+    assert response.status_code == 404
+    assert response.body == b""
+
+
+def test_browser_gets_html_404(not_found, monkeypatch):
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: _user(_bot(web_url="https://cab.example")))
+    monkeypatch.setattr(not_found, "render_template", lambda name, context: f"<html>{context['home_url']}</html>")
+
+    response = not_found.render_not_found(
+        _request("text/html,application/xhtml+xml"), db=object(), token="whatever-long-token"
+    )
+
+    assert response.status_code == 404
+    assert b"https://cab.example" in response.body

--- a/tests/test_not_found_page.py
+++ b/tests/test_not_found_page.py
@@ -1,0 +1,160 @@
+"""Контекст 404-страницы подписки (NPVPN-1762).
+
+`app/subscription/not_found.py` на уровне модуля тянет `app.db` (Session/crud) —
+тяжёлую зависимость, недоступную в песочнице `tests/conftest.py` (см. её докстринг
+про заглушку `app`). Поэтому стабим ровно `app.db` через monkeypatch и грузим
+модуль напрямую через importlib, как это делает tests/test_settings_apps_managed_gate.py.
+
+monkeypatch (а не голое присвоение в sys.modules) — чтобы не перетереть заглушки
+других тестов: при полном прогоне `pytest -q` файлы делят один процесс и один
+sys.modules.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).parent.parent
+
+
+def _bot(*, web_url: str = "", bot_url: str = "", show_ads: bool = True):
+    """Бот с настройками, как их отдаёт BotSettings.data."""
+    return SimpleNamespace(
+        settings=SimpleNamespace(data={"web_url": web_url, "bot_url": bot_url, "show_ads": show_ads})
+    )
+
+
+def _user(bot):
+    return SimpleNamespace(bot=bot)
+
+
+@pytest.fixture
+def not_found(monkeypatch):
+    db_module = sys.modules.get("app.db")
+    if db_module is None:
+        db_module = types.ModuleType("app.db")
+        monkeypatch.setitem(sys.modules, "app.db", db_module)
+    if not hasattr(db_module, "Session"):
+        monkeypatch.setattr(db_module, "Session", object, raising=False)
+
+    crud_module = getattr(db_module, "crud", None)
+    if crud_module is None:
+        crud_module = types.SimpleNamespace()
+        monkeypatch.setattr(db_module, "crud", crud_module, raising=False)
+    if not hasattr(crud_module, "get_user"):
+        monkeypatch.setattr(crud_module, "get_user", lambda db, username: None, raising=False)
+    if not hasattr(crud_module, "get_bots"):
+        monkeypatch.setattr(crud_module, "get_bots", lambda db: [], raising=False)
+
+    spec = importlib.util.spec_from_file_location(
+        "app.subscription.not_found", _ROOT / "app" / "subscription" / "not_found.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "app.subscription.not_found", module)
+    spec.loader.exec_module(module)
+    # Токен не подделываем: подпись проверяет реальный get_subscription_payload,
+    # а нас интересует ветвление после успешного разбора.
+    monkeypatch.setattr(module, "get_subscription_payload", lambda token: {"username": "42_7"})
+    return module
+
+
+def test_home_url_prefers_web_url(not_found, monkeypatch):
+    bot = _bot(web_url="https://cab.example", bot_url="https://t.me/bot")
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: _user(bot))
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    assert ctx["home_url"] == "https://cab.example"
+
+
+def test_home_url_falls_back_to_bot_url(not_found, monkeypatch):
+    bot = _bot(web_url="", bot_url="https://t.me/bot")
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: _user(bot))
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    assert ctx["home_url"] == "https://t.me/bot"
+
+
+def test_home_url_empty_when_bot_has_no_links(not_found, monkeypatch):
+    bot = _bot(web_url="", bot_url="")
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: _user(bot))
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    assert ctx["home_url"] == ""
+
+
+def test_single_bot_used_when_user_not_found(not_found, monkeypatch):
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: None)
+    monkeypatch.setattr(not_found.crud, "get_bots", lambda db: [_bot(web_url="https://only.example")])
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    assert ctx["home_url"] == "https://only.example"
+
+
+def test_multi_bot_gives_no_link(not_found, monkeypatch):
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: None)
+    monkeypatch.setattr(
+        not_found.crud,
+        "get_bots",
+        lambda db: [_bot(web_url="https://one.example"), _bot(web_url="https://two.example")],
+    )
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    # Ни чужой бот, ни env-дефолт: на мультиботовой панели угадывать нечего.
+    assert ctx["home_url"] == ""
+
+
+def test_no_bots_uses_env_defaults(not_found, monkeypatch):
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: None)
+    monkeypatch.setattr(not_found.crud, "get_bots", lambda db: [])
+    monkeypatch.setattr(
+        not_found, "apply_bot_settings_fallback", lambda raw: {"web_url": "", "bot_url": "https://t.me/env"}
+    )
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    assert ctx["home_url"] == "https://t.me/env"
+
+
+def test_show_ads_taken_from_bot_settings(not_found, monkeypatch):
+    bot = _bot(web_url="https://cab.example", show_ads=False)
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: _user(bot))
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    assert ctx["show_ads"] is False
+
+
+def test_db_error_does_not_break_page(not_found, monkeypatch):
+    def _boom(db, username):
+        raise RuntimeError("db is down")
+
+    monkeypatch.setattr(not_found.crud, "get_user", _boom)
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    assert ctx == {"home_url": "", "show_ads": True}
+
+
+def test_unparsable_token_skips_user_lookup(not_found, monkeypatch):
+    monkeypatch.setattr(not_found, "get_subscription_payload", lambda token: None)
+
+    def _must_not_be_called(db, username):
+        raise AssertionError("get_user не должен вызываться при неразобранном токене")
+
+    monkeypatch.setattr(not_found.crud, "get_user", _must_not_be_called)
+    monkeypatch.setattr(not_found.crud, "get_bots", lambda db: [_bot(bot_url="https://t.me/only")])
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="garbage")
+
+    assert ctx["home_url"] == "https://t.me/only"

--- a/tests/test_not_found_page.py
+++ b/tests/test_not_found_page.py
@@ -187,3 +187,29 @@ def test_browser_gets_html_404(not_found, monkeypatch):
 
     assert response.status_code == 404
     assert b"https://cab.example" in response.body
+
+
+def _render_real_template(context: dict) -> str:
+    """Рендер боевого templates/sub/not_found.html через тот же jinja-env, что и панель."""
+    import jinja2
+
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader([str(_ROOT / "templates"), str(_ROOT / "app/templates")]))
+    return env.get_template("sub/not_found.html").render(context)
+
+
+def test_template_renders_link_when_home_url_set():
+    html = _render_real_template({"home_url": "https://cab.example", "show_ads": True})
+
+    assert '<a href="https://cab.example"' in html
+    assert "<button" not in html
+
+
+def test_template_hides_button_without_home_url():
+    html = _render_real_template({"home_url": "", "show_ads": True})
+
+    assert "dark-btn" not in html
+
+
+def test_template_footer_respects_show_ads():
+    assert "npvpn" not in _render_real_template({"home_url": "", "show_ads": False})
+    assert "npvpn" in _render_real_template({"home_url": "", "show_ads": True})

--- a/tests/test_not_found_page.py
+++ b/tests/test_not_found_page.py
@@ -107,6 +107,12 @@ def test_multi_bot_gives_no_link(not_found, monkeypatch):
         "get_bots",
         lambda db: [_bot(web_url="https://one.example"), _bot(web_url="https://two.example")],
     )
+    # apply_bot_settings_fallback(None) подставил бы env BOT_URL — застабленное
+    # значение узнаваемо не-пустое, чтобы тест реально ловил регресс на этот вызов,
+    # а не полагался на то, что DEFAULT_BOT_SETTINGS["bot_url"] в тестовой среде пуст.
+    monkeypatch.setattr(
+        not_found, "apply_bot_settings_fallback", lambda raw: {"web_url": "", "bot_url": "https://t.me/env-default"}
+    )
 
     ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
 
@@ -114,16 +120,50 @@ def test_multi_bot_gives_no_link(not_found, monkeypatch):
     assert ctx["home_url"] == ""
 
 
-def test_no_bots_uses_env_defaults(not_found, monkeypatch):
-    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: None)
-    monkeypatch.setattr(not_found.crud, "get_bots", lambda db: [])
+def test_user_found_without_own_bot_gives_no_link(not_found, monkeypatch):
+    """Мультиботовая панель, у найденного пользователя bot is None (бот удалён) —
+    ступень 1 не должна подставлять чужого/env-бота, а провалиться на ступень 3."""
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: _user(bot=None))
     monkeypatch.setattr(
-        not_found, "apply_bot_settings_fallback", lambda raw: {"web_url": "", "bot_url": "https://t.me/env"}
+        not_found.crud,
+        "get_bots",
+        lambda db: [_bot(web_url="https://one.example"), _bot(web_url="https://two.example")],
+    )
+    monkeypatch.setattr(
+        not_found, "apply_bot_settings_fallback", lambda raw: {"web_url": "", "bot_url": "https://t.me/env-default"}
     )
 
     ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
 
+    assert ctx["home_url"] == ""
+
+
+def test_no_bots_uses_env_defaults(not_found, monkeypatch):
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: None)
+    monkeypatch.setattr(not_found.crud, "get_bots", lambda db: [])
+    received_raw = []
+
+    def _fallback(raw):
+        received_raw.append(raw)
+        return {"web_url": "", "bot_url": "https://t.me/env"}
+
+    monkeypatch.setattr(not_found, "apply_bot_settings_fallback", _fallback)
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    # Ноль ботов в панели -> raw должен быть None: это и есть «взяли env-дефолты»,
+    # а не просто проброс произвольного значения через стаб.
+    assert received_raw == [None]
     assert ctx["home_url"] == "https://t.me/env"
+
+
+def test_unsafe_url_scheme_gives_no_link(not_found, monkeypatch):
+    bot = _bot(web_url="", bot_url="javascript:alert(1)")
+    monkeypatch.setattr(not_found.crud, "get_user", lambda db, username: _user(bot))
+
+    ctx = not_found.build_not_found_page_context(db=object(), token="whatever-long-token")
+
+    assert ctx["home_url"] == ""
 
 
 def test_show_ads_taken_from_bot_settings(not_found, monkeypatch):


### PR DESCRIPTION
Задача: [NPVPN-1762](https://ru.yougile.com/team/9a0e05abf438)
<!-- reviewer:task-link -->

## NPVPN-1504 — страница 404 (FE)

- добавила новую страницу - not_found.html
- в subscription.py добавила функцию handle_not_found
- подключила к эндпоинтам: 
  - user_subscription 
  - revoke_subscription_device 
  - user_subscription_with_client_type 

## NPVPN-1762 — куда ведёт кнопка (BE)

Кнопка «На главную» была закомментирована, потому что вести ей было некуда: шаблон рендерился без контекста. Теперь она ведёт в веб-кабинет или в телеграм-бота.

Сложность в том, что 404 отдаётся ровно тогда, когда пользователь не найден, а `bot_url`/`web_url` в панели хранятся пер-бот и резолвятся от пользователя. Поэтому бот определяется в три ступени, от точного к грубому:

1. **По токену** — он разбирается (подпись валидна) даже когда пользователь пересоздан или переименован; тогда запись в базе есть и бот известен точно. Берутся только собственные настройки этого бота.
2. **Одноботовая панель** — пользователя нет, но и выбирать не из чего. Ноль ботов = классический одиночный Marzban, где ссылка живёт в env.
3. **Мультиботовая панель** — угадывать нечего, ссылки нет и кнопка не рисуется. Через `apply_bot_settings_fallback(None)` здесь идти нельзя: он подставит env `BOT_URL` и уведёт клиента белого лейбла в чужого бота.

Ссылка = `web_url`, иначе `bot_url`, иначе пусто. Значения с непозволенной схемой (`javascript:` и подобные) отбрасываются — общий jinja-Environment панели создан без autoescape.

Что изменилось в коде:

- новый сервис `app/subscription/not_found.py`: резолв бота, контекст страницы (ровно два ключа — `home_url` и `show_ads`) и отдача ответа. Браузеру — HTML со статусом 404, VPN-клиентам и API — пустой `Response(404)` без похода в базу;
- `handle_not_found` из роутера убрана, три точки 404 зовут `render_not_found(request, db, token)` — логика уехала в сервис;
- `app/subscription/bot_settings.py` больше не тянет `app.db.models` в рантайме (аннотация под `TYPE_CHECKING`);
- в `not_found.html` кнопка вернулась как `<a href="{{ home_url }}">` под `{% if home_url %}` — по образцу `expired.html`/`revoked.html`; удалён безусловный дубль футера, из-за которого флаг `show_ads` ни на что не влиял;
- `tests/test_not_found_page.py` — 16 тестов: все три ступени резолва, приоритет ссылок, пользователь без своего бота, отсечение небезопасной схемы, устойчивость к ошибке БД, Accept-гейт и рендер боевого шаблона.

Проверки: `ruff check` и `ruff format --check` чисто, `pytest` — 250 passed, `mypy-baseline filter` — новых ошибок нет.

Проверить руками на стенде: битую ссылку `/sub/<мусор>` в браузере, её же через `curl` без `Accept: text/html` (должен быть пустой 404), и протухший токен существующего пользователя (кнопка ведёт в его кабинет).
