### PR TITLE
NPVPN-1784: темная тема для блока поиска по ботам

### DIFF
--- a/app/dashboard/src/components/Filters.tsx
+++ b/app/dashboard/src/components/Filters.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from "react-i18next";
 import ReactSelect from "react-select";
 import { fetch } from "service/http";
 import { Bot } from "types/Bot";
+import { useBotSelectStyles } from "hooks/useBotSelectStyles";
 
 const iconProps = {
   baseStyle: {
@@ -53,72 +54,9 @@ interface BotOption {
   label: string;
 }
 
-const customStyles: StylesConfig<BotOption, false> = {
-  control: (base) => ({
-    ...base,
-    minHeight: 40,
-    height: 40,
-    fontSize: 16,
-    borderColor: "var(--chakra-colors-light-border)",
-    boxShadow: "none",
-    "&:hover": {
-      borderColor: "var(--chakra-colors-light-border)",
-    },
-  }),
-
-  valueContainer: (base) => ({
-    ...base,
-    height: 40,
-    padding: "0 12px",
-  }),
-
-  input: (base) => ({
-    ...base,
-    margin: 0,
-    padding: 0,
-    fontSize: 16,
-  }),
-
-  singleValue: (base) => ({
-    ...base,
-    fontSize: 16,
-    margin: 0,
-  }),
-
-  placeholder: (base) => ({
-    ...base,
-    fontSize: 16,
-    margin: 0,
-    color: "var(--chakra-colors-gray-500)",
-  }),
-
-  indicatorsContainer: (base) => ({
-    ...base,
-    height: 40,
-  }),
-
-  clearIndicator: (base) => ({
-    ...base,
-    padding: 8,
-  }),
-
-  dropdownIndicator: (base) => ({
-    ...base,
-    padding: 8,
-  }),
-
-  menuPortal: (base) => ({
-    ...base,
-    zIndex: 9999,
-  }),
-
-  menu: (base) => ({
-    ...base,
-    zIndex: 9999,
-  }),
-};
-
 export const Filters: FC<FilterProps> = ({ ...props }) => {
+  const botSelectStyles = useBotSelectStyles({ variant: "filter" });
+
   const {
     loading,
     filters,
@@ -235,7 +173,7 @@ export const Filters: FC<FilterProps> = ({ ...props }) => {
               noOptionsMessage={() => t("botSettings.noBotsFound")}
               isSearchable
               isClearable
-              styles={customStyles}
+              styles={botSelectStyles}
               menuPortalTarget={document.body}
               menuPosition="fixed"
             />

--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -67,6 +67,7 @@ import classNames from "classnames";
 import { fetch } from "service/http";
 import { DevicesModal } from "./DevicesModal";
 import ReactSelect, { StylesConfig } from "react-select";
+import { useBotSelectStyles } from "hooks/useBotSelectStyles";
 
 const AddUserIcon = chakra(UserPlusIcon, {
   baseStyle: {
@@ -99,71 +100,6 @@ interface BotOption {
   value: string;
   label: string;
 }
-
-const botSelectStyles: StylesConfig<BotOption, false> = {
-  control: (base) => ({
-    ...base,
-    minHeight: 40,
-    height: 40,
-    fontSize: 16,
-    borderColor: "var(--chakra-colors-light-border)",
-    boxShadow: "none",
-    "&:hover": {
-      borderColor: "var(--chakra-colors-light-border)",
-    },
-  }),
-
-  valueContainer: (base) => ({
-    ...base,
-    height: 40,
-    padding: "0 12px",
-  }),
-
-  input: (base) => ({
-    ...base,
-    margin: 0,
-    padding: 0,
-    fontSize: 16,
-  }),
-
-  singleValue: (base) => ({
-    ...base,
-    fontSize: 16,
-    margin: 0,
-  }),
-
-  placeholder: (base) => ({
-    ...base,
-    fontSize: 16,
-    margin: 0,
-    color: "var(--chakra-colors-gray-500)",
-  }),
-
-  indicatorsContainer: (base) => ({
-    ...base,
-    height: 40,
-  }),
-
-  clearIndicator: (base) => ({
-    ...base,
-    padding: 8,
-  }),
-
-  dropdownIndicator: (base) => ({
-    ...base,
-    padding: 8,
-  }),
-
-  menuPortal: (base) => ({
-    ...base,
-    zIndex: 9999,
-  }),
-
-  menu: (base) => ({
-    ...base,
-    zIndex: 9999,
-  }),
-};
 
 const formatUser = (user: User): FormType => {
   return {
@@ -304,6 +240,8 @@ const schema = z.discriminatedUnion("status", [
 ]);
 
 export const UserDialog: FC<UserDialogProps> = () => {
+  const botSelectStyles = useBotSelectStyles();
+
   const {
     editingUser,
     isCreatingNewUser,

--- a/app/dashboard/src/hooks/useBotSelectStyles.tsx
+++ b/app/dashboard/src/hooks/useBotSelectStyles.tsx
@@ -1,0 +1,107 @@
+import { useColorModeValue, useToken } from "@chakra-ui/react";
+import { StylesConfig } from "react-select";
+
+interface BotOption {
+  value: string;
+  label: string;
+}
+
+type BotSelectVariant = "default" | "filter";
+
+interface UseBotSelectStylesProps {
+  variant?: BotSelectVariant;
+}
+
+export const useBotSelectStyles = ({
+  variant = "default",
+}: UseBotSelectStylesProps = {}): StylesConfig<BotOption, false> => {
+  const bgToken = useColorModeValue(
+    variant === "filter" ? "chakra-body-bg" : "white",
+    variant === "filter" ? "gray.800" : "gray.700"
+  );
+
+  const textToken = useColorModeValue("gray.800", "white");
+
+  const borderToken = useColorModeValue(
+    variant === "filter" ? "gray.600" : "gray.200",
+    "gray.600"
+  );
+
+  const placeholderToken = useColorModeValue("gray.500", "gray.400");
+  const hoverToken = useColorModeValue("primary.50", "primary.900");
+  const selectedToken = useColorModeValue("primary.500", "primary.200");
+
+  const [bg, text, border, placeholder, hover, selected] = useToken("colors", [
+    bgToken,
+    textToken,
+    borderToken,
+    placeholderToken,
+    hoverToken,
+    selectedToken,
+  ]);
+
+  return {
+    control: (base, state) => ({
+      ...base,
+      minHeight: 40,
+      height: 40,
+      backgroundColor: bg,
+      borderColor: state.isFocused ? selected : border,
+      boxShadow: "none",
+      "&:hover": {
+        borderColor: border,
+      },
+    }),
+
+    valueContainer: (base) => ({
+      ...base,
+      height: 40,
+      padding: "0 12px",
+    }),
+
+    input: (base) => ({
+      ...base,
+      color: text,
+    }),
+
+    singleValue: (base) => ({
+      ...base,
+      color: text,
+    }),
+
+    placeholder: (base) => ({
+      ...base,
+      color: placeholder,
+    }),
+
+    menu: (base) => ({
+      ...base,
+      backgroundColor: bg,
+    }),
+
+    option: (base, state) => ({
+      ...base,
+      backgroundColor: state.isSelected
+        ? selected
+        : state.isFocused
+        ? hover
+        : bg,
+      color: state.isSelected ? "white" : text,
+    }),
+
+    clearIndicator: (base) => ({
+      ...base,
+      color: placeholder,
+    }),
+
+    dropdownIndicator: (base) => ({
+      ...base,
+      color: placeholder,
+    }),
+
+    menuPortal: (base) => ({
+      ...base,
+      zIndex: 9999,
+    }),
+  };
+};


### PR DESCRIPTION
Добавила хук **useBotSelectStyles** с параметром variant для стилизации **react-select** с поддержкой цветовой темы Chakra UI. Поддерживает два варианта: default и filter. 
В filter варианте исправлены цвета бордера и фона для соответствия дизайну