### PR TITLE
NPVPN-1800: открывать ЛК в текущей вкладке, не в новом табе

### DIFF
--- a/templates/sub/expired.html
+++ b/templates/sub/expired.html
@@ -137,11 +137,11 @@
         </div>
 
         {% if web_url %}
-        <div class="button-wrapper_revoke">
-          <a href="{{ web_url }}" target="_blank" rel="noopener noreferrer" class="dark-btn">
-            Войти в личный кабинет
-          </a>
-        </div>
+          <div class="button-wrapper_revoke">
+            <a href="{{ web_url }}" class="dark-btn">
+              Войти в личный кабинет
+            </a>
+          </div>
         {% endif %}
       </div>
 

--- a/templates/sub/index.html
+++ b/templates/sub/index.html
@@ -480,7 +480,7 @@ sudo apt install ./Happ.linux.x64.deb
 
                {% if web_url %}
               <div class="button-wrapper">
-                <a href="{{ web_url }}" target="_blank" rel="noopener noreferrer"
+                <a href="{{ web_url }}"
                     class="w-full flex items-center justify-center font-bold py-4 transition-colors text-lg" style="font-family: var(--third-family)">
                     Войти в личный кабинет
                 </a>

--- a/templates/sub/index.html
+++ b/templates/sub/index.html
@@ -478,7 +478,7 @@ sudo apt install ./Happ.linux.x64.deb
             </div>
 
 
-               {% if web_url %}
+            {% if web_url %}
               <div class="button-wrapper">
                 <a href="{{ web_url }}"
                     class="w-full flex items-center justify-center font-bold py-4 transition-colors text-lg" style="font-family: var(--third-family)">

--- a/templates/sub/limited.html
+++ b/templates/sub/limited.html
@@ -340,11 +340,11 @@
       </div>
 
       <footer class="footer_limited">
-        {% if web_url %}
-          <button class="limited-btn" onclick="window.open('{{ web_url }}', '_blank')" rel="noopener noreferrer">
-            Перейти в личный кабинет
-          </button>
-        {% endif %}
+          {% if web_url %}
+            <a href="{{ web_url }}" class="limited-btn">
+              Перейти в личный кабинет
+            </a>
+          {% endif %}
           {% if show_ads %}
           <p>
             Сайт работает на платформе

--- a/templates/sub/revoked.html
+++ b/templates/sub/revoked.html
@@ -127,16 +127,11 @@
         </div>
   
         {% if web_url %}
-        <div class="button-wrapper_revoke">
-          <a
-            href="{{ web_url }}"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="dark-btn"
-          >
-            Войти в личный кабинет
-          </a>
-        </div>
+          <div class="button-wrapper_revoke">
+            <a href="{{ web_url }}" class="dark-btn">
+              Войти в личный кабинет
+            </a>
+          </div>
         {% endif %}
       </div>  
 

--- a/templates/sub/styles/components.css
+++ b/templates/sub/styles/components.css
@@ -206,6 +206,7 @@
 
 .limited-btn {
     display: flex;
+    font-size: 16px;
     justify-content: center;
     align-items: center;
     background-color: #f6f6f6;
@@ -714,6 +715,7 @@
 
 .dark-btn {
     border-radius: 40px;
+    font-size: 16px;
     font-family: var(--third-family);
     text-decoration: none;
     color: var(--white);
@@ -1023,10 +1025,6 @@
         width: 420px;
         z-index: 200;
         margin: 0;
-    }
-
-    .limited-btn {
-        font-size: 16px;
     }
     
     .config-btn {

--- a/templates/sub/styles/components.css
+++ b/templates/sub/styles/components.css
@@ -209,7 +209,9 @@
     justify-content: center;
     align-items: center;
     background-color: #f6f6f6;
-    padding: 16px;
+    color: var(--black);
+    text-decoration: none;
+    padding: 16px 0;
     border: none;
     border-radius: 100px;
     font-family: var(--third-family);
@@ -713,6 +715,7 @@
 .dark-btn {
     border-radius: 40px;
     font-family: var(--third-family);
+    text-decoration: none;
     color: var(--white);
     padding: 16px 20px;
     border: none;


### PR DESCRIPTION
## Проблема

На мобильных устройствах при переходе в личный кабинет со страницы-
заглушки панели и попытке авторизоваться через Telegram
пользователя выбрасывало обратно на страницу панели — авторизация
не завершалась.

При этом:
- на десктопе через панель всё работало (flow идёт через popup +
  postMessage, без выхода из браузера)
- при прямом заходе на сайт (без панели) на мобильном тоже всё
  работало

## Причина

Кнопка "Перейти в личный кабинет" открывала веб-сайт в новой
вкладке (target="_blank" / window.open). На мобильных Telegram
OAuth инициирует переход в приложение Telegram для подтверждения
входа (app-switch), браузер уходит в фон. Вкладка, открытая
программно и имеющая вкладку-родителя (панель), в такой ситуации
может быть выгружена браузером как менее приоритетная — при
возврате из Telegram браузер показывает предыдущую (родительскую)
вкладку, то есть панель.

Никакого прямого редиректа на домен панели в коде фронтенда сайта
нет — переход происходит на уровне браузера/ОС, не в JS.

## Решение

Убрала target="_blank" у всех ссылок на web_url в шаблонах панели —
переход теперь происходит в текущей вкладке, без создания
"дочерней" вкладки с родителем. Одну кнопку (button + window.open)
заменила на обычную <a href>.

## Как проверялось

- [x] Панель → ЛК → вход через Telegram на мобильном (Android/Chrome)
- [x] Панель → ЛК → вход через Telegram на мобильном (iOS/Safari)
- [x] Панель → ЛК → вход через Telegram во встроенном браузере
- [x] Десктоп-сценарий не сломан (панель → ЛК → вход через Telegram)
- [x] Прямой заход на сайт без панели по-прежнему работает