### PR TITLE
NPVPN-1775/sync-settings

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -371,5 +371,13 @@
   "botSettings.draftRestore": "Restore",
   "botSettings.draftDiscard": "Discard",
   "botSettings.botSearchPlaceholder": "Search bot",
-  "botSettings.botSearchEmpty": "No bots found"
+  "botSettings.botSearchEmpty": "No bots found",
+  "botSettings.adminSync": "Sync from admin panel",
+  "botSettings.adminSyncHint": "Allow the admin panel to push this bot's identity, URLs, and subscription domain.",
+  "botSettings.adminSyncNewBotHint": "Enabled by default for new bots. Fields stay editable until the first managed update is received.",
+  "botSettings.adminSyncEnabled": "Admin sync enabled",
+  "botSettings.adminSyncDisabled": "Admin sync disabled",
+  "botSettings.adminSyncFailed": "Failed to update admin sync",
+  "botSettings.managedBanner": "Some fields are managed by {{source}} (version {{version}}). Other bot settings remain editable.",
+  "botSettings.managedFieldHint": "Managed by the admin panel. Disable admin sync to edit this field and stop future managed updates."
 }

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -319,5 +319,13 @@
   "botSettings.draftRestore": "بازیابی",
   "botSettings.draftDiscard": "رد کردن",
   "botSettings.botSearchPlaceholder": "جستجوی ربات با نام کاربری یا عنوان",
-  "botSettings.botSearchEmpty": "رباتی یافت نشد"
+  "botSettings.botSearchEmpty": "رباتی یافت نشد",
+  "botSettings.adminSync": "همگام‌سازی از پنل مدیریت",
+  "botSettings.adminSyncHint": "به پنل مدیریت اجازه دهید مشخصات، لینک‌ها و دامنه اشتراک این ربات را ارسال کند.",
+  "botSettings.adminSyncNewBotHint": "برای ربات‌های جدید به‌صورت پیش‌فرض فعال است. فیلدها تا دریافت اولین به‌روزرسانی مدیریت‌شده قابل ویرایش می‌مانند.",
+  "botSettings.adminSyncEnabled": "همگام‌سازی پنل مدیریت فعال شد",
+  "botSettings.adminSyncDisabled": "همگام‌سازی پنل مدیریت غیرفعال شد",
+  "botSettings.adminSyncFailed": "به‌روزرسانی همگام‌سازی پنل مدیریت ناموفق بود",
+  "botSettings.managedBanner": "برخی فیلدها توسط {{source}} مدیریت می‌شوند (نسخه {{version}}). سایر تنظیمات ربات همچنان قابل ویرایش هستند.",
+  "botSettings.managedFieldHint": "این فیلد توسط پنل مدیریت کنترل می‌شود. برای ویرایش و توقف به‌روزرسانی‌های بعدی، همگام‌سازی مدیریت را غیرفعال کنید."
 }

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -372,5 +372,13 @@
   "botSettings.draftRestore": "Восстановить",
   "botSettings.draftDiscard": "Отклонить",
   "botSettings.botSearchPlaceholder": "Поиск бота",
-  "botSettings.botSearchEmpty": "Боты не найдены"
+  "botSettings.botSearchEmpty": "Боты не найдены",
+  "botSettings.adminSync": "Синхронизация из админки",
+  "botSettings.adminSyncHint": "Разрешить админке отправлять данные бота, ссылки и домен подписки.",
+  "botSettings.adminSyncNewBotHint": "Для новых ботов включено по умолчанию. Поля доступны для редактирования до первой управляемой синхронизации.",
+  "botSettings.adminSyncEnabled": "Синхронизация с админкой включена",
+  "botSettings.adminSyncDisabled": "Синхронизация с админкой выключена",
+  "botSettings.adminSyncFailed": "Не удалось изменить синхронизацию с админкой",
+  "botSettings.managedBanner": "Часть полей управляется источником {{source}} (версия {{version}}). Остальные настройки бота доступны для редактирования.",
+  "botSettings.managedFieldHint": "Поле управляется админкой. Отключите синхронизацию, чтобы редактировать его и остановить дальнейшие обновления."
 }

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -315,5 +315,13 @@
   "botSettings.draftRestore": "恢复",
   "botSettings.draftDiscard": "丢弃",
   "botSettings.botSearchPlaceholder": "按用户名或名称搜索机器人",
-  "botSettings.botSearchEmpty": "未找到机器人"
+  "botSettings.botSearchEmpty": "未找到机器人",
+  "botSettings.adminSync": "从管理面板同步",
+  "botSettings.adminSyncHint": "允许管理面板推送此机器人的身份信息、链接和订阅域名。",
+  "botSettings.adminSyncNewBotHint": "新机器人默认启用。在收到首次托管更新之前，字段仍可编辑。",
+  "botSettings.adminSyncEnabled": "已启用管理面板同步",
+  "botSettings.adminSyncDisabled": "已禁用管理面板同步",
+  "botSettings.adminSyncFailed": "更新管理面板同步失败",
+  "botSettings.managedBanner": "部分字段由 {{source}} 管理（版本 {{version}}）。其他机器人设置仍可编辑。",
+  "botSettings.managedFieldHint": "此字段由管理面板管理。禁用管理同步后即可编辑，并会停止后续托管更新。"
 }

--- a/app/dashboard/src/components/BotSettingsDialog.tsx
+++ b/app/dashboard/src/components/BotSettingsDialog.tsx
@@ -1,4 +1,7 @@
 import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
   Box,
   Button,
   FormControl,
@@ -114,11 +117,14 @@ export const BotSettingsDialog: FC = () => {
   const [saving, setSaving] = useState(false);
   const [creating, setCreating] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [syncingAdmin, setSyncingAdmin] = useState(false);
   const [defaultSettings, setDefaultSettings] =
     useState<BotSettings>(emptySettings);
   const [botUsername, setBotUsername] = useState("");
   const [botTitle, setBotTitle] = useState("");
   const [settings, setSettings] = useState<BotSettings>(emptySettings);
+  const [serverSettings, setServerSettings] =
+    useState<BotSettings>(emptySettings);
   const [hasDraft, setHasDraft] = useState(false);
   const [botSearch, setBotSearch] = useState("");
   const [isBotListOpen, setIsBotListOpen] = useState(false);
@@ -216,6 +222,7 @@ export const BotSettingsDialog: FC = () => {
       setBotUsername("");
       setBotTitle("");
       replaceSettings(emptySettings);
+      setServerSettings(emptySettings);
       const newDraft = localStorage.getItem(NEW_BOT_DRAFT_KEY);
       setHasDraft(!!newDraft);
       return;
@@ -231,6 +238,7 @@ export const BotSettingsDialog: FC = () => {
       .then((serverSettings) => {
         if (cancelled) return;
         replaceSettings(serverSettings);
+        setServerSettings(serverSettings);
 
         const draftKey = getDraftKey(selectedBot);
         const draft = localStorage.getItem(draftKey);
@@ -255,9 +263,21 @@ export const BotSettingsDialog: FC = () => {
     const draft = localStorage.getItem(key);
     if (!draft) return;
     const parsed = JSON.parse(draft);
-    replaceSettings(parsed.settings);
-    setBotUsername(parsed.botUsername);
-    setBotTitle(parsed.botTitle);
+    const managed = !!(serverSettings.managed || selectedBotModel?.managed);
+    replaceSettings(
+      managed
+        ? {
+            ...parsed.settings,
+            bot_url: serverSettings.bot_url,
+            web_url: serverSettings.web_url,
+            sub_support_url: serverSettings.sub_support_url,
+            sub_subscription_domain: serverSettings.sub_subscription_domain,
+            managed: serverSettings.managed,
+          }
+        : parsed.settings
+    );
+    setBotUsername(managed ? selectedBotModel?.username || "" : parsed.botUsername);
+    setBotTitle(managed ? selectedBotModel?.title || "" : parsed.botTitle);
     localStorage.removeItem(key);
     setHasDraft(false);
   };
@@ -273,6 +293,63 @@ export const BotSettingsDialog: FC = () => {
     () => bots.find((bot) => bot.username === selectedBot),
     [bots, selectedBot]
   );
+
+  const managedState = settings.managed || selectedBotModel?.managed || null;
+  const isManaged = !!managedState;
+  const adminSyncEnabled = selectedBotModel?.admin_sync_enabled ?? true;
+
+  const setAdminSync = (enabled: boolean) => {
+    if (!selectedBot) return;
+    setSyncingAdmin(true);
+    fetch<Bot | { admin_sync_enabled: boolean }>(
+      `/bots/${selectedBot}/admin-sync`,
+      {
+        method: "PATCH",
+        body: { enabled },
+      }
+    )
+      .then((updated) => {
+        if (
+          !updated.admin_sync_enabled ||
+          ("managed" in updated && !updated.managed)
+        ) {
+          setSettings((current) => ({ ...current, managed: null }));
+          setServerSettings((current) => ({ ...current, managed: null }));
+        }
+        setBots((current) =>
+          current.map((bot) =>
+            bot.username === selectedBot
+              ? {
+                  ...bot,
+                  ...("id" in updated ? updated : {}),
+                  admin_sync_enabled: updated.admin_sync_enabled,
+                }
+              : bot
+          )
+        );
+        toast({
+          title: t(
+            updated.admin_sync_enabled
+              ? "botSettings.adminSyncEnabled"
+              : "botSettings.adminSyncDisabled"
+          ),
+          status: "success",
+          duration: 2500,
+          isClosable: true,
+          position: "top",
+        });
+      })
+      .catch(() => {
+        toast({
+          title: t("botSettings.adminSyncFailed"),
+          status: "error",
+          duration: 2500,
+          isClosable: true,
+          position: "top",
+        });
+      })
+      .finally(() => setSyncingAdmin(false));
+  };
 
   const defaultListFieldTexts = useMemo(
     () => toListFieldTexts(defaultSettings),
@@ -354,10 +431,21 @@ export const BotSettingsDialog: FC = () => {
     if (!normalizedUsername) return;
     const normalizedTitle = botTitle.trim();
     const isIdentityChanged =
-      normalizedUsername !== selectedBot ||
-      normalizedTitle !== (selectedBotModel?.title || "");
+      !isManaged &&
+      (normalizedUsername !== selectedBot ||
+        normalizedTitle !== (selectedBotModel?.title || ""));
+    const { managed: _managed, updated_at: _updatedAt, ...editableSettings } =
+      settings;
     const settingsPayload = {
-      ...settings,
+      ...editableSettings,
+      ...(isManaged
+        ? {
+            bot_url: serverSettings.bot_url,
+            web_url: serverSettings.web_url,
+            sub_support_url: serverSettings.sub_support_url,
+            sub_subscription_domain: serverSettings.sub_subscription_domain,
+          }
+        : {}),
       sub_revoked_server_text: toList(listFieldTexts.sub_revoked_server_text),
       sub_expired_server_text: toList(listFieldTexts.sub_expired_server_text),
       sub_device_limit_server_text: toList(
@@ -684,12 +772,56 @@ export const BotSettingsDialog: FC = () => {
                 </HStack>
               </HStack>
             )}
+            <VStack mt={3} spacing={3} align="stretch">
+              <FormControl
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                borderWidth="1px"
+                borderRadius="md"
+                px={4}
+                py={3}
+              >
+                <Box pr={4}>
+                  <FormLabel mb={0}>
+                    {t("botSettings.adminSync")}
+                  </FormLabel>
+                  <FormHelperText mt={1}>
+                    {selectedBot
+                      ? t("botSettings.adminSyncHint")
+                      : t("botSettings.adminSyncNewBotHint")}
+                  </FormHelperText>
+                </Box>
+                <Switch
+                  colorScheme="primary"
+                  isChecked={selectedBot ? adminSyncEnabled : true}
+                  isDisabled={!selectedBot || syncingAdmin}
+                  onChange={(event) => setAdminSync(event.target.checked)}
+                />
+              </FormControl>
+              {isManaged && (
+                <Alert
+                  status="info"
+                  variant="left-accent"
+                  borderRadius="md"
+                  alignItems="flex-start"
+                >
+                  <AlertIcon mt={0.5} />
+                  <AlertDescription fontSize="sm">
+                    {t("botSettings.managedBanner", {
+                      source: managedState?.source,
+                      version: managedState?.version,
+                    })}
+                  </AlertDescription>
+                </Alert>
+              )}
+            </VStack>
             <TabPanels minH="400px" pt={2}>
               {/* Вкладка 1: Bot Info */}
               <TabPanel px={0}>
                 <VStack spacing={4} align="stretch">
                   <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
-                    <FormControl>
+                    <FormControl isDisabled={isManaged}>
                       <FormLabel>{t("botSettings.newBotUsername")}</FormLabel>
                       <Input
                         value={botUsername}
@@ -700,10 +832,12 @@ export const BotSettingsDialog: FC = () => {
                         placeholder="@my_vpn_bot"
                       />
                       <FormHelperText>
-                        {t("botSettings.newBotUsernameHint")}
+                        {isManaged
+                          ? t("botSettings.managedFieldHint")
+                          : t("botSettings.newBotUsernameHint")}
                       </FormHelperText>
                     </FormControl>
-                    <FormControl>
+                    <FormControl isDisabled={isManaged}>
                       <FormLabel>{t("botSettings.newBotTitle")}</FormLabel>
                       <Input
                         value={botTitle}
@@ -714,13 +848,15 @@ export const BotSettingsDialog: FC = () => {
                         placeholder="My VPN Bot"
                       />
                       <FormHelperText>
-                        {t("botSettings.newBotTitleHint")}
+                        {isManaged
+                          ? t("botSettings.managedFieldHint")
+                          : t("botSettings.newBotTitleHint")}
                       </FormHelperText>
                     </FormControl>
                   </SimpleGrid>
 
                   <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
-                    <FormControl>
+                    <FormControl isDisabled={isManaged}>
                       <FormLabel>{t("botSettings.botUrl")}</FormLabel>
                       <Input
                         value={settings.bot_url}
@@ -730,10 +866,12 @@ export const BotSettingsDialog: FC = () => {
                         }
                       />
                       <FormHelperText>
-                        {t("botSettings.botUrlHint")}
+                        {isManaged
+                          ? t("botSettings.managedFieldHint")
+                          : t("botSettings.botUrlHint")}
                       </FormHelperText>
                     </FormControl>
-                    <FormControl>
+                    <FormControl isDisabled={isManaged}>
                       <FormLabel>{t("botSettings.webUrl")}</FormLabel>
                       <Input
                         value={settings.web_url}
@@ -743,7 +881,9 @@ export const BotSettingsDialog: FC = () => {
                         }
                       />
                       <FormHelperText>
-                        {t("botSettings.webUrlHint")}
+                        {isManaged
+                          ? t("botSettings.managedFieldHint")
+                          : t("botSettings.webUrlHint")}
                       </FormHelperText>
                     </FormControl>
                   </SimpleGrid>
@@ -768,7 +908,7 @@ export const BotSettingsDialog: FC = () => {
               <TabPanel px={0}>
                 <VStack spacing={4} align="stretch">
                   <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
-                    <FormControl>
+                    <FormControl isDisabled={isManaged}>
                       <FormLabel>{t("botSettings.subSupportUrl")}</FormLabel>
                       <Input
                         value={settings.sub_support_url}
@@ -778,7 +918,9 @@ export const BotSettingsDialog: FC = () => {
                         }
                       />
                       <FormHelperText>
-                        {t("botSettings.subSupportUrlHint")}
+                        {isManaged
+                          ? t("botSettings.managedFieldHint")
+                          : t("botSettings.subSupportUrlHint")}
                       </FormHelperText>
                     </FormControl>
                     <FormControl>
@@ -810,7 +952,7 @@ export const BotSettingsDialog: FC = () => {
                         {t("botSettings.subProfileUrlHint")}
                       </FormHelperText>
                     </FormControl>
-                    <FormControl>
+                    <FormControl isDisabled={isManaged}>
                       <FormLabel>
                         {t("botSettings.subSubscriptionDomain")}
                       </FormLabel>
@@ -824,7 +966,9 @@ export const BotSettingsDialog: FC = () => {
                         }
                       />
                       <FormHelperText>
-                        {t("botSettings.subSubscriptionDomainHint")}
+                        {isManaged
+                          ? t("botSettings.managedFieldHint")
+                          : t("botSettings.subSubscriptionDomainHint")}
                       </FormHelperText>
                     </FormControl>
                   </SimpleGrid>

--- a/app/dashboard/src/types/Bot.ts
+++ b/app/dashboard/src/types/Bot.ts
@@ -1,7 +1,17 @@
+export type ManagedState = {
+  key: string;
+  version: string;
+  source: string;
+  applied_at: string | null;
+};
+
 export type Bot = {
   id: number;
   username: string;
   title?: string | null;
+  source_bot_id?: number | null;
+  admin_sync_enabled: boolean;
+  managed?: ManagedState | null;
 };
 
 export type BotSettings = {
@@ -34,4 +44,9 @@ export type BotSettings = {
   bs_extra_reset_pool_on_prolong: boolean;
   show_ads: boolean;
   updated_at?: string;
+  managed?: ManagedState | null;
+};
+
+export type AdminSyncUpdate = {
+  enabled: boolean;
 };

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -291,6 +291,10 @@ def get_bot(db: Session, bot_username: str) -> Bot | None:
     return db.query(Bot).filter(Bot.username == normalized).first()
 
 
+def get_bot_by_source_id(db: Session, source_bot_id: int) -> Bot | None:
+    return db.query(Bot).filter(Bot.source_bot_id == source_bot_id).first()
+
+
 def get_bots(db: Session) -> list[Bot]:
     return db.query(Bot).order_by(Bot.username.asc()).all()
 
@@ -313,14 +317,27 @@ def _set_bot_web_url(db: Session, bot: Bot, web_url: str | None) -> None:
     db.commit()
 
 
-def create_bot(db: Session, username: str, title: str | None = None, web_url: str | None = None) -> Bot:
+def create_bot(
+    db: Session,
+    username: str,
+    title: str | None = None,
+    web_url: str | None = None,
+    *,
+    source_bot_id: int | None = None,
+    admin_sync_enabled: bool = True,
+) -> Bot:
     normalized = _normalize_bot_username(username)
     if not normalized:
         raise ValueError("Bot username is required")
     if get_bot(db, normalized):
         raise ValueError(f'Bot "{normalized}" already exists')
 
-    bot = Bot(username=normalized, title=title or None)
+    bot = Bot(
+        username=normalized,
+        title=title or None,
+        source_bot_id=source_bot_id,
+        admin_sync_enabled=admin_sync_enabled,
+    )
     db.add(bot)
     db.commit()
     db.refresh(bot)
@@ -378,6 +395,13 @@ def update_bot_settings(db: Session, bot: Bot, settings_data: dict[str, Any]) ->
     db.commit()
     db.refresh(settings)
     return dict(settings.data or {})
+
+
+def set_bot_admin_sync_enabled(db: Session, bot: Bot, enabled: bool) -> Bot:
+    cast(Any, bot).admin_sync_enabled = enabled
+    db.commit()
+    db.refresh(bot)
+    return bot
 
 
 UsersSortingOptions = Enum(

--- a/app/db/migrations/versions/b6e1d4f8a2c7_per_bot_managed_settings.py
+++ b/app/db/migrations/versions/b6e1d4f8a2c7_per_bot_managed_settings.py
@@ -16,22 +16,13 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Existing bots must opt in. After the columns are installed, the database
-    # default is switched to true so bots created by newer code start enabled.
+    # Sync from admin is on by default for every bot, including existing ones.
     with op.batch_alter_table("bots") as batch_op:
         batch_op.add_column(sa.Column("source_bot_id", sa.BigInteger(), nullable=True))
         batch_op.add_column(
-            sa.Column("admin_sync_enabled", sa.Boolean(), nullable=False, server_default=sa.false())
+            sa.Column("admin_sync_enabled", sa.Boolean(), nullable=False, server_default=sa.true())
         )
         batch_op.create_index("ix_bots_source_bot_id", ["source_bot_id"], unique=True)
-
-    with op.batch_alter_table("bots") as batch_op:
-        batch_op.alter_column(
-            "admin_sync_enabled",
-            existing_type=sa.Boolean(),
-            nullable=False,
-            server_default=sa.true(),
-        )
 
 
 def downgrade() -> None:

--- a/app/db/migrations/versions/b6e1d4f8a2c7_per_bot_managed_settings.py
+++ b/app/db/migrations/versions/b6e1d4f8a2c7_per_bot_managed_settings.py
@@ -1,0 +1,41 @@
+"""per bot managed settings
+
+Revision ID: b6e1d4f8a2c7
+Revises: 9b1d29ea4018
+Create Date: 2026-08-10 16:05:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "b6e1d4f8a2c7"
+down_revision = "9b1d29ea4018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Existing bots must opt in. After the columns are installed, the database
+    # default is switched to true so bots created by newer code start enabled.
+    with op.batch_alter_table("bots") as batch_op:
+        batch_op.add_column(sa.Column("source_bot_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(
+            sa.Column("admin_sync_enabled", sa.Boolean(), nullable=False, server_default=sa.false())
+        )
+        batch_op.create_index("ix_bots_source_bot_id", ["source_bot_id"], unique=True)
+
+    with op.batch_alter_table("bots") as batch_op:
+        batch_op.alter_column(
+            "admin_sync_enabled",
+            existing_type=sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("bots") as batch_op:
+        batch_op.drop_index("ix_bots_source_bot_id")
+        batch_op.drop_column("admin_sync_enabled")
+        batch_op.drop_column("source_bot_id")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -79,6 +79,8 @@ class Bot(Base):
     id = Column(Integer, primary_key=True)
     username = Column(String(64), unique=True, index=True, nullable=False)
     title = Column(String(128), nullable=True, default=None)
+    source_bot_id = Column(BigInteger, unique=True, index=True, nullable=True)
+    admin_sync_enabled = Column(Boolean, nullable=False, default=True, server_default=text("1"))
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/app/models/bot.py
+++ b/app/models/bot.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.models.managed import ManagedStateResponse
 from config import (
     BOT_URL,
     SUB_BS_LIMIT_ANNOUNCE_TEXT,
@@ -93,6 +94,9 @@ class BotUpdate(BaseModel):
 
 class BotResponse(BotBase):
     id: int
+    source_bot_id: int | None = None
+    admin_sync_enabled: bool
+    managed: ManagedStateResponse | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -158,6 +162,14 @@ class BotSettingsPayload(BaseModel):
         # '' / None → допустимо (поле не задано); иначе обязан быть JSON-объект.
         parse_json_object(value)
         return value if value is not None else ""
+
+
+class BotSettingsResponse(BotSettingsPayload):
+    managed: ManagedStateResponse | None = None
+
+
+class BotAdminSyncUpdate(BaseModel):
+    enabled: bool
 
 
 def apply_bot_settings_fallback(raw_settings: dict[str, Any] | None) -> dict[str, Any]:

--- a/app/models/managed.py
+++ b/app/models/managed.py
@@ -2,13 +2,43 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ManagedPushRequest(BaseModel):
     data: dict[str, Any] = Field(default_factory=dict)
     version: str = ""
     source: str = ""
+
+
+class ManagedBotSettingsPayload(BaseModel):
+    username: str = Field(min_length=1, max_length=64)
+    title: str | None = Field(None, max_length=128)
+    bot_url: str
+    web_url: str
+    sub_support_url: str
+    sub_subscription_domain: str
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("username")
+    @classmethod
+    def normalize_username(cls, value: str) -> str:
+        normalized = value.strip().lstrip("@")
+        if not normalized:
+            raise ValueError("Bot username is required")
+        return normalized
+
+    @field_validator("title")
+    @classmethod
+    def normalize_title(cls, value: str | None) -> str | None:
+        return value.strip() if value and value.strip() else None
+
+    @field_validator("sub_subscription_domain", mode="before")
+    @classmethod
+    def normalize_subscription_domain(cls, value: Any) -> str:
+        from app.subscription.subscription_url import normalize_subscription_domain
+
+        return normalize_subscription_domain(value)
 
 
 class ManagedStateResponse(BaseModel):

--- a/app/routers/bot.py
+++ b/app/routers/bot.py
@@ -5,15 +5,29 @@ from app.db import Session, crud, get_db
 from app.models.admin import Admin
 from app.models.bot import (
     DEFAULT_BOT_SETTINGS,
+    BotAdminSyncUpdate,
     BotCreate,
     BotResponse,
     BotSettingsPayload,
+    BotSettingsResponse,
     BotUpdate,
     apply_bot_settings_fallback,
 )
+from app.services import managed_settings as managed_svc
 from app.utils import responses
 
 router = APIRouter(tags=["Bot"], prefix="/api", responses={401: responses._401})
+
+
+def _bot_response(db: Session, bot) -> dict:
+    return {
+        "id": bot.id,
+        "username": bot.username,
+        "title": bot.title,
+        "source_bot_id": bot.source_bot_id,
+        "admin_sync_enabled": bot.admin_sync_enabled,
+        "managed": managed_svc.read_bot_managed_state(db, bot),
+    }
 
 
 @router.get("/bots", response_model=list[BotResponse])
@@ -22,7 +36,7 @@ def get_bots(
     admin: Admin = Depends(Admin.get_current),
 ):
     del admin  # explicit auth dependency
-    return crud.get_bots(db)
+    return [_bot_response(db, bot) for bot in crud.get_bots(db)]
 
 
 @router.get("/bots/default-settings", response_model=BotSettingsPayload)
@@ -41,7 +55,8 @@ def create_bot(
 ):
     del admin
     try:
-        return crud.create_bot(db, payload.username, payload.title, payload.web_url)
+        bot = crud.create_bot(db, payload.username, payload.title, payload.web_url)
+        return _bot_response(db, bot)
     except ValueError as err:
         raise HTTPException(status_code=400, detail=str(err))
 
@@ -77,16 +92,44 @@ def update_bot(
     if not bot:
         raise HTTPException(status_code=404, detail="Bot not found")
     try:
+        managed_svc.ensure_bot_identity_update_allowed(
+            db,
+            bot,
+            username=payload.username,
+            title=payload.title,
+            web_url=payload.web_url,
+        )
         updated_bot = crud.update_bot(db, bot, payload.username, payload.title, payload.web_url)
+    except managed_svc.ManagedFieldChangeError:
+        raise HTTPException(status_code=409, detail="managed_by_admin")
     except ValueError as err:
         raise HTTPException(status_code=400, detail=str(err))
     xray.hosts.update()
-    return updated_bot
+    return _bot_response(db, updated_bot)
+
+
+@router.patch(
+    "/bots/{bot_username}/admin-sync",
+    response_model=BotResponse,
+    responses={403: responses._403, 404: responses._404},
+)
+def update_bot_admin_sync(
+    bot_username: str,
+    payload: BotAdminSyncUpdate,
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.check_sudo_admin),
+):
+    del admin
+    bot = crud.get_bot(db, bot_username)
+    if not bot:
+        raise HTTPException(status_code=404, detail="Bot not found")
+    managed_svc.set_bot_admin_sync(db, bot, payload.enabled)
+    return _bot_response(db, bot)
 
 
 @router.get(
     "/bots/{bot_username}/settings",
-    response_model=BotSettingsPayload,
+    response_model=BotSettingsResponse,
     responses={403: responses._403, 404: responses._404},
 )
 def get_bot_settings(
@@ -98,12 +141,14 @@ def get_bot_settings(
     bot = crud.get_bot(db, bot_username)
     if not bot:
         raise HTTPException(status_code=404, detail="Bot not found")
-    return apply_bot_settings_fallback(crud.get_bot_settings(db, bot))
+    result = apply_bot_settings_fallback(crud.get_bot_settings(db, bot))
+    result["managed"] = managed_svc.read_bot_managed_state(db, bot)
+    return result
 
 
 @router.put(
     "/bots/{bot_username}/settings",
-    response_model=BotSettingsPayload,
+    response_model=BotSettingsResponse,
     responses={403: responses._403, 404: responses._404},
 )
 def update_bot_settings(
@@ -117,5 +162,11 @@ def update_bot_settings(
     if not bot:
         raise HTTPException(status_code=404, detail="Bot not found")
     data = payload.model_dump()
+    try:
+        managed_svc.ensure_bot_settings_update_allowed(db, bot, data)
+    except managed_svc.ManagedFieldChangeError:
+        raise HTTPException(status_code=409, detail="managed_by_admin")
     updated = crud.update_bot_settings(db, bot, data)
-    return apply_bot_settings_fallback(updated)
+    result = apply_bot_settings_fallback(updated)
+    result["managed"] = managed_svc.read_bot_managed_state(db, bot)
+    return result

--- a/app/routers/managed.py
+++ b/app/routers/managed.py
@@ -10,6 +10,53 @@ from app.utils import responses
 router = APIRouter(tags=["Managed"], prefix="/api", responses={401: responses._401})
 
 
+@router.put("/managed/{key}/bots/{source_bot_id}", response_model=ManagedStateResponse)
+def push_managed_bot(
+    key: str,
+    source_bot_id: int,
+    payload: ManagedPushRequest,
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.get_current),
+):
+    del admin
+    if key not in svc.MANAGED_BOT_SECTIONS:
+        raise HTTPException(status_code=404, detail="unknown managed key")
+    try:
+        return svc.apply_managed_bot_push(
+            db,
+            key,
+            source_bot_id,
+            data=payload.data,
+            version=payload.version,
+            source=payload.source,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors())
+    except svc.AdminSyncDisabledError:
+        raise HTTPException(status_code=409, detail="admin_sync_disabled")
+    except svc.ManagedBotConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+
+@router.get("/managed/{key}/bots/{source_bot_id}", response_model=ManagedStateResponse)
+def get_managed_bot(
+    key: str,
+    source_bot_id: int,
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.get_current),
+):
+    del admin
+    if key not in svc.MANAGED_BOT_SECTIONS:
+        raise HTTPException(status_code=404, detail="unknown managed key")
+    try:
+        state = svc.read_managed_bot_state(db, key, source_bot_id)
+    except svc.AdminSyncDisabledError:
+        raise HTTPException(status_code=409, detail="admin_sync_disabled")
+    if state is None:
+        raise HTTPException(status_code=404, detail="not managed")
+    return state
+
+
 @router.put("/managed/{key}", response_model=ManagedStateResponse)
 def push_managed(
     key: str,

--- a/app/services/managed_settings.py
+++ b/app/services/managed_settings.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, cast
 
+from app.models.managed import ManagedBotSettingsPayload
 from app.models.settings import CLIENT_APPS_KEY, ClientAppsPayload
 
 if TYPE_CHECKING:
@@ -28,6 +30,45 @@ def _validate_client_apps(data: dict[str, Any]) -> dict[str, Any]:
 MANAGED_SECTIONS: dict[str, ManagedSection] = {
     CLIENT_APPS_KEY: ManagedSection(key=CLIENT_APPS_KEY, scope="global", validate=_validate_client_apps),
 }
+
+BOT_SETTINGS_KEY = "bot_settings"
+BOT_MANAGED_SETTINGS_FIELDS = frozenset(
+    {"username", "title", "bot_url", "web_url", "sub_support_url", "sub_subscription_domain"}
+)
+BOT_MANAGED_IDENTITY_FIELDS = frozenset({"username", "title", "web_url"})
+BOT_MANAGED_JSON_FIELDS = frozenset({"bot_url", "web_url", "sub_support_url", "sub_subscription_domain"})
+
+
+def _validate_bot_settings(data: dict[str, Any]) -> dict[str, Any]:
+    normalized = ManagedBotSettingsPayload.model_validate(data).model_dump()
+    normalized["web_url"] = _normalize_web_url(normalized["web_url"])
+    return normalized
+
+
+MANAGED_BOT_SECTIONS: dict[str, ManagedSection] = {
+    BOT_SETTINGS_KEY: ManagedSection(key=BOT_SETTINGS_KEY, scope="bot", validate=_validate_bot_settings),
+}
+
+
+class AdminSyncDisabledError(Exception):
+    pass
+
+
+class ManagedBotConflictError(Exception):
+    pass
+
+
+class ManagedFieldChangeError(Exception):
+    pass
+
+
+def _normalize_web_url(value: Any) -> str:
+    domain = str(value or "").strip().replace("https://", "").replace("http://", "").strip("/")
+    return f"https://{domain}" if domain else ""
+
+
+def bot_managed_state_key(source_bot_id: int) -> str:
+    return f"{BOT_SETTINGS_KEY}:{source_bot_id}"
 
 
 def validate_managed_payload(key: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -55,6 +96,150 @@ def unlink_managed(db: Session, key: str) -> bool:
     from app.db import crud
 
     return crud.delete_managed_setting(db, key)
+
+
+def apply_managed_bot_push(
+    db: Session,
+    key: str,
+    source_bot_id: int,
+    *,
+    data: dict[str, Any],
+    version: str,
+    source: str,
+) -> dict[str, Any]:
+    from app.db.models import Bot, BotSettings, ManagedSetting
+
+    section = MANAGED_BOT_SECTIONS[key]
+    normalized = section.validate(data)
+
+    bot = db.query(Bot).filter(Bot.source_bot_id == source_bot_id).first()
+    username_match = db.query(Bot).filter(Bot.username == normalized["username"]).first()
+    if bot is None:
+        bot = username_match
+        if bot is not None and bot.source_bot_id not in (None, source_bot_id):
+            raise ManagedBotConflictError("source_bot_id_conflict")
+    elif username_match is not None and username_match.id != bot.id:
+        raise ManagedBotConflictError("bot_username_conflict")
+
+    if bot is None:
+        bot = Bot(
+            username=normalized["username"],
+            title=normalized["title"],
+            source_bot_id=source_bot_id,
+            admin_sync_enabled=True,
+        )
+        db.add(bot)
+        db.flush()
+    elif not bot.admin_sync_enabled:
+        raise AdminSyncDisabledError
+
+    bot_row = cast(Any, bot)
+    bot_row.source_bot_id = source_bot_id
+    bot_row.username = normalized["username"]
+    bot_row.title = normalized["title"]
+
+    settings = db.query(BotSettings).filter(BotSettings.bot_id == bot.id).first()
+    if settings is None:
+        settings = BotSettings(bot_id=bot.id, data={})
+        db.add(settings)
+    merged = dict(settings.data or {})
+    for field in BOT_MANAGED_JSON_FIELDS:
+        merged[field] = normalized[field]
+    cast(Any, settings).data = merged
+
+    state_key = bot_managed_state_key(source_bot_id)
+    state = db.query(ManagedSetting).filter(ManagedSetting.key == state_key).first()
+    if state is None:
+        state = ManagedSetting(key=state_key, scope=section.scope, source=source, version=version)
+        db.add(state)
+    else:
+        state_row = cast(Any, state)
+        state_row.scope = section.scope
+        state_row.source = source
+        state_row.version = version
+        state_row.applied_at = datetime.utcnow()
+
+    db.commit()
+    db.refresh(state)
+    return _as_state(
+        {
+            "key": state.key,
+            "version": state.version,
+            "source": state.source,
+            "applied_at": state.applied_at,
+        }
+    )
+
+
+def read_managed_bot_state(db: Session, key: str, source_bot_id: int) -> dict[str, Any] | None:
+    from app.db import crud
+
+    bot = crud.get_bot_by_source_id(db, source_bot_id)
+    if bot is None:
+        return None
+    if not bot.admin_sync_enabled:
+        raise AdminSyncDisabledError
+    return read_managed_state(db, bot_managed_state_key(source_bot_id))
+
+
+def read_bot_managed_state(db: Session, bot: Any) -> dict[str, Any] | None:
+    if bot.source_bot_id is None:
+        return None
+    return read_managed_state(db, bot_managed_state_key(int(bot.source_bot_id)))
+
+
+def set_bot_admin_sync(db: Session, bot: Any, enabled: bool) -> None:
+    from app.db.models import ManagedSetting
+
+    bot.admin_sync_enabled = enabled
+    if not enabled and bot.source_bot_id is not None:
+        db.query(ManagedSetting).filter(ManagedSetting.key == bot_managed_state_key(int(bot.source_bot_id))).delete(
+            synchronize_session=False
+        )
+    db.commit()
+    db.refresh(bot)
+
+
+def ensure_bot_identity_update_allowed(
+    db: Session,
+    bot: Any,
+    *,
+    username: str,
+    title: str | None,
+    web_url: str | None,
+) -> None:
+    if read_bot_managed_state(db, bot) is None:
+        return
+    from app.db import crud
+    from app.models.bot import apply_bot_settings_fallback
+
+    current_settings = apply_bot_settings_fallback(crud.get_bot_settings(db, bot))
+    requested = {
+        "username": username.strip().lstrip("@"),
+        "title": title.strip() if isinstance(title, str) and title.strip() else None,
+        "web_url": _normalize_web_url(current_settings.get("web_url") if web_url is None else web_url),
+    }
+    current = {
+        "username": bot.username,
+        "title": bot.title,
+        "web_url": _normalize_web_url(current_settings.get("web_url")),
+    }
+    if requested != current:
+        raise ManagedFieldChangeError
+
+
+def ensure_bot_settings_update_allowed(db: Session, bot: Any, data: dict[str, Any]) -> None:
+    if read_bot_managed_state(db, bot) is None:
+        return
+    from app.db import crud
+    from app.models.bot import apply_bot_settings_fallback
+
+    current = apply_bot_settings_fallback(crud.get_bot_settings(db, bot))
+    for field in BOT_MANAGED_JSON_FIELDS:
+        requested_value = _normalize_web_url(data[field]) if field == "web_url" else data[field]
+        current_value = _normalize_web_url(current[field]) if field == "web_url" else current[field]
+        if requested_value != current_value:
+            raise ManagedFieldChangeError
 
 
 def _as_state(row: dict[str, Any]) -> dict[str, Any]:

--- a/app/services/managed_settings.py
+++ b/app/services/managed_settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     # тянуться при импорте модуля (см. crud-функции ниже — там app.db
     # импортируется лениво, внутри функций, которым реально нужна db).
     from app.db import Session
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -111,14 +114,44 @@ def apply_managed_bot_push(
 
     section = MANAGED_BOT_SECTIONS[key]
     normalized = section.validate(data)
+    logger.info(
+        "managed bot push: key=%s source_bot_id=%s username=%s version=%s source=%s",
+        key,
+        source_bot_id,
+        normalized.get("username"),
+        version,
+        source,
+    )
 
     bot = db.query(Bot).filter(Bot.source_bot_id == source_bot_id).first()
     username_match = db.query(Bot).filter(Bot.username == normalized["username"]).first()
     if bot is None:
         bot = username_match
+        if bot is not None:
+            logger.info(
+                "managed bot push: bound existing bot by username=%s panel_bot_id=%s "
+                "current_source_bot_id=%s admin_sync_enabled=%s",
+                bot.username,
+                bot.id,
+                bot.source_bot_id,
+                bot.admin_sync_enabled,
+            )
         if bot is not None and bot.source_bot_id not in (None, source_bot_id):
+            logger.warning(
+                "managed bot push conflict: username=%s already bound to source_bot_id=%s",
+                bot.username,
+                bot.source_bot_id,
+            )
             raise ManagedBotConflictError("source_bot_id_conflict")
     elif username_match is not None and username_match.id != bot.id:
+        logger.warning(
+            "managed bot push conflict: source_bot_id=%s maps to panel_bot_id=%s "
+            "but username=%s belongs to panel_bot_id=%s",
+            source_bot_id,
+            bot.id,
+            normalized["username"],
+            username_match.id,
+        )
         raise ManagedBotConflictError("bot_username_conflict")
 
     if bot is None:
@@ -130,7 +163,19 @@ def apply_managed_bot_push(
         )
         db.add(bot)
         db.flush()
+        logger.info(
+            "managed bot push: created panel bot id=%s username=%s source_bot_id=%s",
+            bot.id,
+            bot.username,
+            source_bot_id,
+        )
     elif not bot.admin_sync_enabled:
+        logger.warning(
+            "managed bot push rejected: admin_sync_disabled panel_bot_id=%s username=%s source_bot_id=%s",
+            bot.id,
+            bot.username,
+            source_bot_id,
+        )
         raise AdminSyncDisabledError
 
     bot_row = cast(Any, bot)
@@ -161,6 +206,13 @@ def apply_managed_bot_push(
 
     db.commit()
     db.refresh(state)
+    logger.info(
+        "managed bot push applied: panel_bot_id=%s source_bot_id=%s state_key=%s version=%s",
+        bot.id,
+        source_bot_id,
+        state.key,
+        state.version,
+    )
     return _as_state(
         {
             "key": state.key,
@@ -191,10 +243,29 @@ def read_bot_managed_state(db: Session, bot: Any) -> dict[str, Any] | None:
 def set_bot_admin_sync(db: Session, bot: Any, enabled: bool) -> None:
     from app.db.models import ManagedSetting
 
+    previous = bool(bot.admin_sync_enabled)
     bot.admin_sync_enabled = enabled
     if not enabled and bot.source_bot_id is not None:
-        db.query(ManagedSetting).filter(ManagedSetting.key == bot_managed_state_key(int(bot.source_bot_id))).delete(
-            synchronize_session=False
+        deleted = (
+            db.query(ManagedSetting)
+            .filter(ManagedSetting.key == bot_managed_state_key(int(bot.source_bot_id)))
+            .delete(synchronize_session=False)
+        )
+        logger.info(
+            "admin sync disabled for panel bot id=%s username=%s source_bot_id=%s unlinked=%s",
+            bot.id,
+            bot.username,
+            bot.source_bot_id,
+            deleted,
+        )
+    else:
+        logger.info(
+            "admin sync toggled for panel bot id=%s username=%s source_bot_id=%s %s -> %s",
+            bot.id,
+            bot.username,
+            bot.source_bot_id,
+            previous,
+            enabled,
         )
     db.commit()
     db.refresh(bot)

--- a/tests/test_per_bot_managed_settings.py
+++ b/tests/test_per_bot_managed_settings.py
@@ -1,0 +1,174 @@
+import sys
+import types
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Model imports reach app.subscription.share through app.models.user. The test
+# only needs the bot tables, so avoid loading subscription rendering machinery.
+_share_stub = types.ModuleType("app.subscription.share")
+_share_stub.generate_v2ray_links = lambda *args, **kwargs: []
+sys.modules.setdefault("app.subscription.share", _share_stub)
+
+from app.db.base import Base
+from app.db.models import Bot, BotSettings, ManagedSetting
+from app.models.bot import apply_bot_settings_fallback
+from app.services import managed_settings as svc
+
+MANAGED_DATA = {
+    "username": "synced_bot",
+    "title": "Synced bot",
+    "bot_url": "https://t.me/synced_bot",
+    "web_url": "panel.example.com",
+    "sub_support_url": "https://t.me/support",
+    "sub_subscription_domain": "sub.example.com",
+}
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine, tables=[Bot.__table__, BotSettings.__table__, ManagedSetting.__table__])
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_first_push_binds_by_username_and_preserves_panel_only_settings(db):
+    bot = Bot(username="synced_bot", admin_sync_enabled=True)
+    db.add(bot)
+    db.flush()
+    db.add(BotSettings(bot_id=bot.id, data={"show_ads": False, "panel_only": {"keep": True}}))
+    db.commit()
+
+    state = svc.apply_managed_bot_push(
+        db,
+        svc.BOT_SETTINGS_KEY,
+        42,
+        data=MANAGED_DATA,
+        version="v1",
+        source="telegram",
+    )
+
+    db.refresh(bot)
+    settings = db.query(BotSettings).filter(BotSettings.bot_id == bot.id).one().data
+    assert bot.source_bot_id == 42
+    assert bot.title == "Synced bot"
+    assert settings["web_url"] == "https://panel.example.com"
+    assert settings["panel_only"] == {"keep": True}
+    assert settings["show_ads"] is False
+    assert state["key"] == "bot_settings:42"
+    assert state["version"] == "v1"
+
+
+def test_first_push_creates_enabled_bot_and_later_uses_stable_source_id(db):
+    svc.apply_managed_bot_push(
+        db,
+        svc.BOT_SETTINGS_KEY,
+        73,
+        data=MANAGED_DATA,
+        version="v1",
+        source="telegram",
+    )
+    changed = {**MANAGED_DATA, "username": "renamed_bot", "title": None}
+    svc.apply_managed_bot_push(
+        db,
+        svc.BOT_SETTINGS_KEY,
+        73,
+        data=changed,
+        version="v2",
+        source="telegram",
+    )
+
+    bots = db.query(Bot).all()
+    assert len(bots) == 1
+    assert bots[0].username == "renamed_bot"
+    assert bots[0].admin_sync_enabled is True
+
+
+def test_disabled_existing_bot_rejects_push(db):
+    db.add(Bot(username="synced_bot", admin_sync_enabled=False))
+    db.commit()
+
+    with pytest.raises(svc.AdminSyncDisabledError):
+        svc.apply_managed_bot_push(
+            db,
+            svc.BOT_SETTINGS_KEY,
+            42,
+            data=MANAGED_DATA,
+            version="v1",
+            source="telegram",
+        )
+
+
+def test_disabling_unlinks_state_without_changing_values(db):
+    svc.apply_managed_bot_push(
+        db,
+        svc.BOT_SETTINGS_KEY,
+        42,
+        data=MANAGED_DATA,
+        version="v1",
+        source="telegram",
+    )
+    bot = db.query(Bot).filter(Bot.source_bot_id == 42).one()
+    before = dict(db.query(BotSettings).filter(BotSettings.bot_id == bot.id).one().data)
+
+    svc.set_bot_admin_sync(db, bot, False)
+
+    assert svc.read_bot_managed_state(db, bot) is None
+    assert db.query(BotSettings).filter(BotSettings.bot_id == bot.id).one().data == before
+    with pytest.raises(svc.AdminSyncDisabledError):
+        svc.read_managed_bot_state(db, svc.BOT_SETTINGS_KEY, 42)
+
+
+def test_manual_full_settings_payload_allows_unchanged_managed_fields_only(db):
+    svc.apply_managed_bot_push(
+        db,
+        svc.BOT_SETTINGS_KEY,
+        42,
+        data=MANAGED_DATA,
+        version="v1",
+        source="telegram",
+    )
+    bot = db.query(Bot).filter(Bot.source_bot_id == 42).one()
+    full_payload = apply_bot_settings_fallback(db.query(BotSettings).filter(BotSettings.bot_id == bot.id).one().data)
+    full_payload["show_ads"] = False
+
+    svc.ensure_bot_settings_update_allowed(db, bot, full_payload)
+    with pytest.raises(svc.ManagedFieldChangeError):
+        svc.ensure_bot_settings_update_allowed(
+            db,
+            bot,
+            {**full_payload, "sub_support_url": "https://example.com/other"},
+        )
+
+
+def test_manual_identity_payload_allows_unchanged_managed_fields_only(db):
+    svc.apply_managed_bot_push(
+        db,
+        svc.BOT_SETTINGS_KEY,
+        42,
+        data=MANAGED_DATA,
+        version="v1",
+        source="telegram",
+    )
+    bot = db.query(Bot).filter(Bot.source_bot_id == 42).one()
+
+    svc.ensure_bot_identity_update_allowed(
+        db,
+        bot,
+        username=bot.username,
+        title=bot.title,
+        web_url="panel.example.com",
+    )
+    with pytest.raises(svc.ManagedFieldChangeError):
+        svc.ensure_bot_identity_update_allowed(
+            db,
+            bot,
+            username="other_bot",
+            title=bot.title,
+            web_url="panel.example.com",
+        )

--- a/tests/test_per_bot_managed_settings_migration.py
+++ b/tests/test_per_bot_managed_settings_migration.py
@@ -18,3 +18,6 @@ def test_migration_has_upgrade_and_downgrade():
     assert hasattr(module, "upgrade")
     assert hasattr(module, "downgrade")
     assert module.down_revision == "9b1d29ea4018"
+    source = open(module.__file__, encoding="utf-8").read()
+    assert "server_default=sa.true()" in source
+    assert "server_default=sa.false()" not in source

--- a/tests/test_per_bot_managed_settings_migration.py
+++ b/tests/test_per_bot_managed_settings_migration.py
@@ -1,0 +1,20 @@
+import glob
+import importlib.util
+import os
+
+
+def _load_migration():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    matches = glob.glob(os.path.join(here, "app/db/migrations/versions/*_per_bot_managed_settings.py"))
+    assert len(matches) == 1, f"expected exactly one per-bot managed settings migration, got {matches}"
+    spec = importlib.util.spec_from_file_location("per_bot_managed_migration", matches[0])
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_has_upgrade_and_downgrade():
+    module = _load_migration()
+    assert hasattr(module, "upgrade")
+    assert hasattr(module, "downgrade")
+    assert module.down_revision == "9b1d29ea4018"


### PR DESCRIPTION
NPVPN-1775: managed-синхронизация настроек бота из админки

## Что и зачем
Часть настроек бота дублировалась в панели и в админке telegram_bot. Панель принимает managed-push этих полей из админки, помечает их как управляемые и блокирует ручное редактирование, чтобы источник истины был один.

## Изменения
- Миграция: у `bots` добавлены `source_bot_id` и `admin_sync_enabled` (по умолчанию включено для всех ботов)
- API `PUT/GET /api/managed/bot_settings/bots/{source_bot_id}` для per-bot JSON-синка
- Push мержит только whitelist-поля (`username`, `title`, `bot_url`, `web_url`, `sub_support_url`, `sub_subscription_domain`), остальной JSON панели не затирает
- Если `admin_sync_enabled=false` — push отклоняется с `409 admin_sync_disabled`
- После успешного push managed-поля в BotSettingsDialog заблокированы и пояснены; есть переключатель разрешения синка
- Тесты на bind по username/`source_bot_id`, deny gate, merge panel-only полей и unlink при выключении

## Заметки для ревью
- Нужен парный PR в `telegram_bot` NPVPN-1775/sync-settings
- Старые панели без этих ручек продолжают работать автономно; обновлённый бот для них просто получит UNSUPPORTED