### PR TITLE
NPVPN-1842: привязать существующих юзеров к боту на панели с одним ботом

### DIFF
--- a/app/db/migrations/versions/8a985b0c7775_npvpn_1842_backfill_user_bot.py
+++ b/app/db/migrations/versions/8a985b0c7775_npvpn_1842_backfill_user_bot.py
@@ -1,0 +1,43 @@
+"""npvpn 1842 backfill user bot
+
+Проставляет users.bot_id там, где он пуст, — но только на панели ровно с одним ботом.
+
+Причина (NPVPN-1842): в режиме одного бота бот не передавал панели имя бота, юзер
+сохранялся без привязки и получал настройки из переменных окружения панели вместо
+админки. На opl так накопилось 109 920 юзеров из 115 319, и правка настройки в админке
+доезжала до меньшинства.
+
+Правило «ровно один бот» намеренно узкое: на мультиботовой панели владельца строки
+users по ней самой не определить, а ошибиться — значит показать пользователю чужие
+тексты и чужую поддержку. Там миграция не делает ничего.
+
+Revision ID: 8a985b0c7775
+Revises: c4f8a1b2d3e5
+Create Date: 2026-08-14 00:21:46.497833
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '8a985b0c7775'
+down_revision = 'c4f8a1b2d3e5'
+branch_labels = None
+depends_on = None
+
+
+def _backfill(bind) -> None:
+    bot_ids = [row[0] for row in bind.execute(sa.text("SELECT id FROM bots")).fetchall()]
+    if len(bot_ids) != 1:
+        return
+    bind.execute(sa.text("UPDATE users SET bot_id = :bot_id WHERE bot_id IS NULL"), {"bot_id": bot_ids[0]})
+
+
+def upgrade() -> None:
+    _backfill(op.get_bind())
+
+
+def downgrade() -> None:
+    # Какие именно строки были NULL, после апгрейда не восстановить, а привязка сама по
+    # себе данные не портит — откат ничего не делает осознанно.
+    pass

--- a/tests/test_backfill_user_bot_migration.py
+++ b/tests/test_backfill_user_bot_migration.py
@@ -1,0 +1,69 @@
+"""NPVPN-1842: бэкфилл привязки юзеров к боту на single-bot панели."""
+
+import glob
+import importlib.util
+import os
+
+import sqlalchemy as sa
+
+
+def _load_migration():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    matches = glob.glob(os.path.join(here, "app/db/migrations/versions/*_npvpn_1842_backfill_user_bot.py"))
+    assert len(matches) == 1, f"expected exactly one backfill migration, got {matches}"
+    spec = importlib.util.spec_from_file_location("backfill_user_bot_migration", matches[0])
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _prepare(conn, bots: list[int]) -> None:
+    conn.execute(sa.text("CREATE TABLE bots (id INTEGER PRIMARY KEY, username TEXT)"))
+    conn.execute(sa.text("CREATE TABLE users (id INTEGER PRIMARY KEY, bot_id INTEGER)"))
+    for bot_id in bots:
+        conn.execute(sa.text("INSERT INTO bots (id, username) VALUES (:id, :u)"), {"id": bot_id, "u": f"bot{bot_id}"})
+    conn.execute(sa.text("INSERT INTO users (id, bot_id) VALUES (1, NULL), (2, NULL), (3, 7)"))
+
+
+def _bot_ids(conn) -> list:
+    return [row[1] for row in conn.execute(sa.text("SELECT id, bot_id FROM users ORDER BY id")).fetchall()]
+
+
+def test_single_bot_gets_backfilled():
+    module = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.begin() as conn:
+        _prepare(conn, bots=[5])
+
+        module._backfill(conn)
+
+        assert _bot_ids(conn) == [5, 5, 7]
+
+
+def test_multi_bot_panel_is_untouched():
+    module = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.begin() as conn:
+        _prepare(conn, bots=[5, 6])
+
+        module._backfill(conn)
+
+        assert _bot_ids(conn) == [None, None, 7]
+
+
+def test_panel_without_bots_is_untouched():
+    module = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.begin() as conn:
+        _prepare(conn, bots=[])
+
+        module._backfill(conn)
+
+        assert _bot_ids(conn) == [None, None, 7]
+
+
+def test_migration_downgrade_is_noop():
+    module = _load_migration()
+    assert hasattr(module, "upgrade")
+    assert hasattr(module, "downgrade")
+    module.downgrade()


### PR DESCRIPTION
## Что и зачем

В режиме одного бота (`MULTIBOTS` выключен) бот не передавал панели имя бота, юзер сохранялся с пустым `bot_id`, и `_bot_settings_for_user` отдавал ему настройки из переменных окружения панели вместо строки `bot_settings`, которую редактируют в админке.

Замер на проде 13.08.2026: на opl **109 920** юзеров без привязки (22 363 активных) против 5 399 привязанных, непривязанные создаются и сейчас. Настройки при этом расходятся: ссылка поддержки `t.me/oplVPN_support` из env против `t.me/opl_robot` из админки, другой заголовок профиля, своя заметка клиента и server-тексты. Правка в админке доезжала до 5 399 юзеров из 115 319.

Парная правка в боте (чтобы новые юзеры создавались уже привязанными) — npvpn/telegram_bot#222. **Выкатывать эту PR первой.**

## Изменения

- миграция `8a985b0c7775`: проставляет `users.bot_id` там, где он пуст, — но только если в `bots` ровно одна запись;
- тесты миграции на sqlite: один бот / два бота / ноль ботов / no-op `downgrade`.

## Заметки для ревью

- Правило «ровно один бот» намеренно узкое: на мультиботовой панели владельца строки `users` по ней самой не определить, а ошибиться — значит показать пользователю чужие тексты и чужую поддержку. Там миграция не делает ничего (на npvpn это 86 старых записей 2025 года, в основном `expired`/`disabled`).
- `downgrade` пустой осознанно: какие строки были NULL, после апгрейда не восстановить, а привязка сама по себе данные не портит.
- Логика вынесена в `_backfill(bind)` — тем же приёмом, что в `9b1d29ea4018`, чтобы тест мог прогнать её на sqlite-соединении.
- Проверено на локальном контуре с реальным MySQL: миграция применяется (`c4f8a1b2d3e5 → 8a985b0c7775`); после обнуления `bot_id` у трёх юзеров и повторного `downgrade`+`upgrade` привязка восстанавливается.

