### PR TITLE
NPVPN-1614: экспортировать состояние нод в Prometheus

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -203,6 +203,10 @@ from app.utils.memory_metrics import register as _register_memory_metrics  # noq
 
 _register_memory_metrics()
 
+from app.utils.node_metrics import register as _register_node_metrics  # noqa: E402
+
+_register_node_metrics()
+
 from app import dashboard, jobs, routers, telegram  # noqa
 from app.routers import api_router  # noqa
 

--- a/app/utils/node_metrics.py
+++ b/app/utils/node_metrics.py
@@ -1,0 +1,78 @@
+"""Экспортёр состояния нод в Prometheus (NPVPN-1614).
+
+Читает nodes в момент скрейпа — как _DbPoolCollector в db_metrics.py: никаких
+фоновых задач и никакой нагрузки между скрейпами. История доступности живёт в
+Prometheus (retention 15d), а не в панели — в самой БД лежит только текущий
+статус.
+
+Лейбл ровно один — name. Изменчивые поля (status, message, address) в лейблы не
+кладём: лейбл входит в идентичность временного ряда, и меняющийся лейбл рвал бы
+ряд на куски, ломая avg_over_time.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager
+
+from prometheus_client import REGISTRY
+from prometheus_client.core import GaugeMetricFamily
+
+logger = logging.getLogger(__name__)
+
+METRIC_NAME = "marzban_node_up"
+
+
+class NodeUpCollector:
+    """Отдаёт marzban_node_up{name} = 1 для connected, 0 для connecting/error."""
+
+    def __init__(self, session_factory: Callable[[], AbstractContextManager]):
+        self._session_factory = session_factory
+
+    def collect(self) -> Iterator[GaugeMetricFamily]:
+        try:
+            rows = self._read_rows()
+        except Exception as exc:
+            # Скрейп собирает все коллекторы одним обходом: исключение отсюда
+            # уронило бы весь /metrics, а не только метрики нод.
+            logger.warning("[metrics] node collector failed: %s", exc)
+            return
+
+        gauge = GaugeMetricFamily(
+            METRIC_NAME,
+            "Node is connected (1) or not (0); disabled nodes are excluded",
+            labels=["name"],
+        )
+        for name, status in rows:
+            gauge.add_metric([name], 1.0 if status == "connected" else 0.0)
+        yield gauge
+
+    def _read_rows(self) -> list[tuple[str, str]]:
+        # Импорт ленивый: модуль не должен тянуть модели и движок на импорте,
+        # иначе он неимпортируем в тестовой песочнице (tests/conftest.py).
+        from app.db.models import Node
+        from app.models.node import NodeStatus
+
+        with self._session_factory() as db:
+            rows = db.query(Node.name, Node.status).filter(Node.status != NodeStatus.disabled).all()
+
+        return [(name, getattr(status, "value", status)) for name, status in rows]
+
+
+_registered = False
+
+
+def register(session_factory: Callable[[], AbstractContextManager] | None = None) -> None:
+    global _registered
+    if _registered:
+        return
+    if session_factory is None:
+        from app.db import GetDB
+
+        session_factory = GetDB
+    try:
+        REGISTRY.register(NodeUpCollector(session_factory))
+        _registered = True
+    except Exception as exc:
+        logger.warning("[metrics] failed to register node collector: %s", exc)

--- a/tests/test_node_metrics.py
+++ b/tests/test_node_metrics.py
@@ -1,0 +1,98 @@
+"""Экспорт состояния нод в Prometheus (NPVPN-1614)."""
+
+import sys
+import types
+from contextlib import contextmanager
+from datetime import datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+for _name, _module in list(sys.modules.items()):
+    if _name.startswith("app.") and not hasattr(_module, "__file__") and not hasattr(_module, "__path__"):
+        del sys.modules[_name]
+
+_share_stub = types.ModuleType("app.subscription.share")
+_share_stub.generate_v2ray_links = lambda *args, **kwargs: []
+sys.modules.setdefault("app.subscription.share", _share_stub)
+
+from app.db.base import Base  # noqa: E402
+from app.db.models import Node  # noqa: E402
+from app.models.node import NodeStatus  # noqa: E402
+from app.utils.node_metrics import NodeUpCollector  # noqa: E402
+
+if sys.modules.get("app.subscription.share") is _share_stub:
+    del sys.modules["app.subscription.share"]
+
+
+def _node(node_id: int, name: str, status: NodeStatus) -> Node:
+    return Node(
+        id=node_id,
+        name=name,
+        address="127.0.0.1",
+        port=62050,
+        api_port=62051,
+        status=status,
+        created_at=datetime.utcnow(),
+    )
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    session.add(_node(1, "marzban-de-1", NodeStatus.connected))
+    session.add(_node(2, "marzban-nl-2", NodeStatus.error))
+    session.add(_node(3, "marzban-fr-3", NodeStatus.connecting))
+    session.add(_node(4, "marzban-old-4", NodeStatus.disabled))
+    session.commit()
+
+    @contextmanager
+    def factory():
+        yield session
+
+    yield factory
+    session.close()
+
+
+def _samples(collector: NodeUpCollector) -> dict[str, float]:
+    return {sample.labels["name"]: sample.value for family in collector.collect() for sample in family.samples}
+
+
+def test_connected_node_is_up(session_factory):
+    assert _samples(NodeUpCollector(session_factory))["marzban-de-1"] == 1.0
+
+
+def test_error_and_connecting_nodes_are_down(session_factory):
+    samples = _samples(NodeUpCollector(session_factory))
+
+    assert samples["marzban-nl-2"] == 0.0
+    assert samples["marzban-fr-3"] == 0.0
+
+
+def test_disabled_node_is_not_exported(session_factory):
+    # Админ выключил ноду осознанно: это не авария и не простой, иначе она
+    # тянула бы вниз и процент доступности, и суточную статистику.
+    assert "marzban-old-4" not in _samples(NodeUpCollector(session_factory))
+
+
+def test_metric_name_and_labels(session_factory):
+    families = list(NodeUpCollector(session_factory).collect())
+
+    assert len(families) == 1
+    assert families[0].name == "marzban_node_up"
+    assert families[0].samples[0].labels == {"name": "marzban-de-1"}
+
+
+def test_db_failure_does_not_break_scrape():
+    # /metrics собирается одним обходом всех коллекторов: исключение отсюда
+    # уронило бы весь эндпоинт, включая метрики пула и HTTP.
+    @contextmanager
+    def broken_factory():
+        raise RuntimeError("db is down")
+        yield  # pragma: no cover
+
+    assert list(NodeUpCollector(broken_factory).collect()) == []


### PR DESCRIPTION
## Что и зачем

Истории состояний нод нигде не было: в MySQL лежит только текущий `nodes.status`, а Grafana опрашивает его раз в минуту и ничего не накапливает. Из-за этого нельзя ответить ни «сколько времени за сутки нода была офлайн», ни «какая доля парка сейчас жива» — а без этого в боте (NPVPN-1614) не построить ни статистику простоя, ни агрегатный алерт вместо пер-нодового спама в общий чат.

Панель начинает отдавать состояние нод как Prometheus-метрику. Prometheus уже скрейпит панель каждые 15 с и хранит 15 дней, поэтому история появляется без нового хранилища.

## Изменения

- `app/utils/node_metrics.py` — scrape-time коллектор `marzban_node_up{name}`: `connected` → 1, `connecting`/`error` → 0. Механика та же, что у `_DbPoolCollector` в `db_metrics.py` — состояние читается в момент скрейпа, без фоновых задач и без нагрузки между скрейпами.
- Ноды со статусом `disabled` в метрику не попадают вовсе: админ выключил их осознанно, это не авария и не простой, иначе они тянули бы вниз и процент доступности, и статистику.
- `app/__init__.py` — регистрация коллектора рядом с регистрацией метрик пула.
- `tests/test_node_metrics.py` — 5 тестов на in-memory sqlite.

## Заметки для ревью

- **Лейбл ровно один — `name`.** Изменчивые поля (`status`, `message`, `address`) в лейблы намеренно не кладутся: лейбл входит в идентичность временного ряда, и меняющийся лейбл рвал бы ряд на куски, ломая `avg_over_time`.
- **Сбой чтения БД не поднимает исключение наружу** — `/metrics` собирается одним обходом всех коллекторов, и исключение отсюда уронило бы весь эндпоинт, включая метрики пула и HTTP. Есть тест на этот случай.
- Импорт моделей внутри метода, а не на уровне модуля — иначе модуль неимпортируем в тестовой песочнице (`tests/conftest.py` подменяет пакет `app`).
- **Порядок выкатки:** это первая половина задачи, её надо выкатить до PR в боте — без метрики дашборд там пустой, а правила алертинга молчат (`noDataState: OK`).
- Проверено на живом контейнере: `/metrics` отдаёт `marzban_node_up` по всем не-disabled нодам. Учтите, что uvicorn слушает на имени контейнера (`nvb_marz:8001`), а не на `localhost`, и `curl` в образе нет.
- Полезно дать метрике накопиться сутки перед выкаткой бота: `avg_over_time[24h]` на неполном окне завышает доступность.
