### PR TITLE
NPVPN-1827/hosts redesign

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -103,6 +103,7 @@
   "hostsDialog.statusText": "User status",
   "hostsDialog.title": "Using this setting, you are able to assign specific address for each inbound.",
   "hostsDialog.username": "The username of the user",
+  "hostsDialog.header": "Host Settings",
   "inbound": "Inbound",
   "itemsPerPage": "Items per page",
   "login": "Login",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -106,6 +106,7 @@
   "hostsDialog.statusText": "وضعیت کاربر",
   "hostsDialog.title": "با انتخاب این تنظیمات، می‌توانید برای هر ورودی یک آدرس منحصر به فرد انتخاب کنید.",
   "hostsDialog.username": "نام کاربری کاربر",
+  "hostsDialog.header": "تنظیمات میزبان",
   "inbound": "ورودی",
   "itemsPerPage": "تعداد در صفحه",
   "login": "ورود",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -103,6 +103,7 @@
   "hostsDialog.statusText": "Статус пользователя",
   "hostsDialog.title": "Используя эту настройку, Вы можете настроить свои inbound.",
   "hostsDialog.username": "Имя пользователя",
+  "hostsDialog.header": "Настройки хоста",
   "inbound": "inbound",
   "itemsPerPage": "Элементов на страницу",
   "login": "Вход",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -101,6 +101,7 @@
   "hostsDialog.statusText": "用户状态",
   "hostsDialog.title": "使用此设置，您可以为每个入站分配特定的地址。",
   "hostsDialog.username": "用户的用户名",
+  "hostsDialog.header": "主机设置",
   "inbound": "入站",
   "itemsPerPage": "每页条数",
   "login": "登录",

--- a/app/dashboard/src/components/Filters.tsx
+++ b/app/dashboard/src/components/Filters.tsx
@@ -13,7 +13,6 @@ import {
   InputRightElement,
   Spinner,
 } from "@chakra-ui/react";
-import { StylesConfig } from "react-select";
 import {
   ArrowPathIcon,
   MagnifyingGlassIcon,

--- a/app/dashboard/src/components/HostsDialog.tsx
+++ b/app/dashboard/src/components/HostsDialog.tsx
@@ -1,5 +1,7 @@
 import {
+  Box,
   Button,
+  Collapse,
   HStack,
   Input,
   InputGroup,
@@ -15,11 +17,15 @@ import {
   useToast,
   VStack,
 } from "@chakra-ui/react";
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { PlusIcon as HeroIconPlusIcon } from "@heroicons/react/24/outline";
+import {
+  ChevronDownIcon,
+  MagnifyingGlassIcon,
+} from "@heroicons/react/24/outline";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useHosts } from "contexts/HostsContext";
 import { FC, useCallback, useEffect, useMemo, useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { fetch } from "service/http";
 import { Bot } from "types/Bot";
@@ -27,9 +33,10 @@ import { z } from "zod";
 import { useDashboard } from "../contexts/DashboardContext";
 import { NodeType } from "../contexts/NodesContext";
 import { Icon } from "./Icon";
-import { hostsFormSchema } from "./hostsDialog/schema";
+import { hostItemSchema, hostsFormSchema } from "./hostsDialog/schema";
 import { ModalIcon } from "./hostsDialog/constants";
 import { HostsList } from "./hostsDialog/HostsList";
+import { AddHostForm, EMPTY_HOST } from "./hostsDialog/AddHostForm";
 
 type HostsDict = Record<string, any[]>;
 
@@ -80,6 +87,7 @@ export const HostsDialog: FC = () => {
   const [nodes, setNodes] = useState<NodeType[]>([]);
   const [search, setSearch] = useState("");
   const [inboundFilter, setInboundFilter] = useState("");
+  const [isAddingHost, setIsAddingHost] = useState(false);
 
   const inboundMap = useMemo(() => {
     const map = new Map();
@@ -119,6 +127,11 @@ export const HostsDialog: FC = () => {
     resolver: zodResolver(hostsFormSchema),
     shouldUnregister: false,
     defaultValues: { hosts: [] },
+  });
+
+  const { append } = useFieldArray({
+    control: form.control,
+    name: "hosts",
   });
 
   useEffect(() => {
@@ -176,31 +189,74 @@ export const HostsDialog: FC = () => {
     [setHosts, toast, t, refetchUsers, onClose, inboundTags]
   );
 
+  const handleHostAdded = useCallback(
+    (host: z.infer<typeof hostItemSchema>) => {
+      const current = form.getValues("hosts") || [];
+
+      append({
+        ...EMPTY_HOST,
+        ...host,
+        order: current.length,
+      });
+
+      setIsAddingHost(false);
+    },
+    [append, form]
+  );
+
   return (
     <Modal isOpen={isEditingHosts} onClose={onClose}>
       <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
-      <ModalContent mx="3" w="fit-content" maxW="3xl">
+
+      <ModalContent
+        mx="3"
+        w="520px"
+        maxW="calc(100vw - 24px)"
+        h="90vh"
+        maxH="90vh"
+      >
         <ModalHeader pt={6}>
           <Icon color="primary">
             <ModalIcon color="white" />
           </Icon>
         </ModalHeader>
+
         <ModalCloseButton mt={3} />
-        <ModalBody w="520px" pb={3} pt={3}>
+
+        <ModalBody
+          pb={0}
+          pt={3}
+          px={6}
+          display="flex"
+          flexDirection="column"
+          minH={0}
+          overflow="hidden"
+        >
           <FormProvider {...form}>
-            <form onSubmit={form.handleSubmit(handleFormSubmit)}>
-              <Text mb={3} opacity={0.8} fontSize="sm">
+            <form
+              onSubmit={form.handleSubmit(handleFormSubmit)}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                height: "100%",
+                minHeight: 0,
+                overflow: "hidden",
+              }}
+            >
+              <Text mb={3} opacity={0.8} fontSize="sm" flexShrink={0}>
                 {t("hostsDialog.title")}
               </Text>
 
               {isLoading ? (
                 t("hostsDialog.loading")
               ) : (
-                <VStack align="stretch" spacing={3} mb={2}>
-                  <InputGroup>
+                <>
+                  {/* SEARCH */}
+                  <InputGroup flexShrink={0}>
                     <InputLeftElement pointerEvents="none">
                       <MagnifyingGlassIcon width="16px" color="gray" />
                     </InputLeftElement>
+
                     <Input
                       placeholder={
                         t("hostsDialog.search") ?? "Search by remark..."
@@ -211,14 +267,16 @@ export const HostsDialog: FC = () => {
                     />
                   </InputGroup>
 
+                  {/* INBOUND FILTER */}
                   <Select
+                    mt={3}
                     size="md"
+                    flexShrink={0}
                     value={inboundFilter}
                     onChange={(e) => setInboundFilter(e.target.value)}
                   >
-                    <option value="">
-                      {t("hostsDialog.allInbounds")}
-                    </option>
+                    <option value="">{t("hostsDialog.allInbounds")}</option>
+
                     {inboundTags.map((tag) => (
                       <option key={tag} value={tag}>
                         {tag}
@@ -226,18 +284,106 @@ export const HostsDialog: FC = () => {
                     ))}
                   </Select>
 
-                  <HostsList
-                    inboundTags={inboundTags}
-                    inboundFilter={inboundFilter}
-                    search={search}
-                    bots={bots}
-                    nodes={nodes}
-                    inboundMap={inboundMap}
-                  />
-                </VStack>
+                  {/* ADD BUTTON */}
+                  <Button
+                    mt={3}
+                    w="full"
+                    flexShrink={0}
+                    variant="outline"
+                    leftIcon={<HeroIconPlusIcon width="20px" strokeWidth={2} />}
+                    rightIcon={
+                      <ChevronDownIcon
+                        width="16px"
+                        style={{
+                          transform: isAddingHost
+                            ? "rotate(180deg)"
+                            : "rotate(0deg)",
+                          transition: "transform 0.2s ease",
+                        }}
+                      />
+                    }
+                    onClick={() => setIsAddingHost((prev) => !prev)}
+                  >
+                    {t("hostsDialog.addNewHost")}
+                  </Button>
+
+                  <Box
+                    mt={3}
+                    flex={1}
+                    minH={0}
+                    display="flex"
+                    flexDirection="column"
+                    overflow="hidden"
+                  >
+                    {/* ADD HOST FORM */}
+                    <Collapse
+                      in={isAddingHost}
+                      animateOpacity
+                      style={{
+                        flexShrink: 0,
+                      }}
+                    >
+                      <Box pb={3}>
+                        <AddHostForm
+                          inboundTags={inboundTags}
+                          defaultInboundTag={
+                            inboundFilter || inboundTags[0] || ""
+                          }
+                          bots={bots}
+                          nodes={nodes}
+                          inboundMap={inboundMap}
+                          onAdded={handleHostAdded}
+                        />
+                      </Box>
+                    </Collapse>
+                    <Box flex={1} minH={0} overflow="hidden">
+                      <VStack
+                        h="full"
+                        minH={0}
+                        align="stretch"
+                        spacing={3}
+                        overflowY="auto"
+                        pr={2}
+                        sx={{
+                          "&::-webkit-scrollbar": {
+                            width: "4px",
+                          },
+
+                          "&::-webkit-scrollbar-track": {
+                            background: "transparent",
+                          },
+
+                          "&::-webkit-scrollbar-thumb": {
+                            background: "rgba(0, 0, 0, 0.2)",
+                            borderRadius: "999px",
+                          },
+                        }}
+                      >
+                        <HostsList
+                          inboundTags={inboundTags}
+                          inboundFilter={inboundFilter}
+                          search={search}
+                          bots={bots}
+                          nodes={nodes}
+                          inboundMap={inboundMap}
+                        />
+                      </VStack>
+                    </Box>
+                  </Box>
+                </>
               )}
 
-              <HStack justifyContent="flex-end" py={2}>
+              {/* APPLY */}
+              <HStack
+                justifyContent="flex-end"
+                py={3}
+                px={0}
+                flexShrink={0}
+                bg="white"
+                _dark={{
+                  bg: "gray.700",
+                }}
+              >
                 <Button
                   variant="solid"
                   mt="2"

--- a/app/dashboard/src/components/HostsDialog.tsx
+++ b/app/dashboard/src/components/HostsDialog.tsx
@@ -355,14 +355,13 @@ export const HostsDialog: FC = () => {
                         overflowY="auto"
                         pr={2}
                         sx={{
+                          overscrollBehavior: "contain",
                           "&::-webkit-scrollbar": {
                             width: "4px",
                           },
-
                           "&::-webkit-scrollbar-track": {
                             background: "transparent",
                           },
-
                           "&::-webkit-scrollbar-thumb": {
                             background: "rgba(0, 0, 0, 0.2)",
                             borderRadius: "999px",

--- a/app/dashboard/src/components/HostsDialog.tsx
+++ b/app/dashboard/src/components/HostsDialog.tsx
@@ -208,17 +208,29 @@ export const HostsDialog: FC = () => {
     <Modal isOpen={isEditingHosts} onClose={onClose}>
       <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
 
-      <ModalContent
-        mx="3"
-        w="520px"
-        maxW="calc(100vw - 24px)"
-        h="90vh"
-        maxH="90vh"
-      >
+      <ModalContent mx="3" w="full" maxW="2xl" h="90vh" maxH="90vh">
         <ModalHeader pt={6}>
-          <Icon color="primary">
-            <ModalIcon color="white" />
-          </Icon>
+          <HStack spacing={4} align="center">
+            <Icon color="primary">
+              <ModalIcon color="white" />
+            </Icon>
+
+            <Box>
+              <Text fontSize="lg" fontWeight="semibold">
+                {t("hostsDialog.header")}
+              </Text>
+
+              <Text
+                fontSize="sm"
+                opacity={0.6}
+                mt={1}
+                maxW="490px"
+                lineHeight="1.4"
+              >
+                {t("hostsDialog.title")}
+              </Text>
+            </Box>
+          </HStack>
         </ModalHeader>
 
         <ModalCloseButton mt={3} />
@@ -243,48 +255,46 @@ export const HostsDialog: FC = () => {
                 overflow: "hidden",
               }}
             >
-              <Text mb={3} opacity={0.8} fontSize="sm" flexShrink={0}>
-                {t("hostsDialog.title")}
-              </Text>
-
               {isLoading ? (
                 t("hostsDialog.loading")
               ) : (
                 <>
-                  {/* SEARCH */}
-                  <InputGroup flexShrink={0}>
-                    <InputLeftElement pointerEvents="none">
-                      <MagnifyingGlassIcon width="16px" color="gray" />
-                    </InputLeftElement>
+                  <HStack mt={3} spacing={2} flexShrink={0}>
+                    <InputGroup flex="1" minW={0}>
+                      <InputLeftElement pointerEvents="none">
+                        <MagnifyingGlassIcon width="16px" color="gray" />
+                      </InputLeftElement>
+                      <Input
+                        placeholder={
+                          t("hostsDialog.search") ?? "Search by remark..."
+                        }
+                        size="md"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                      />
+                    </InputGroup>
 
-                    <Input
-                      placeholder={
-                        t("hostsDialog.search") ?? "Search by remark..."
-                      }
+                    <Select
                       size="md"
-                      value={search}
-                      onChange={(e) => setSearch(e.target.value)}
-                    />
-                  </InputGroup>
+                      flex="1"
+                      minW={0}
+                      value={inboundFilter}
+                      onChange={(e) => setInboundFilter(e.target.value)}
+                      sx={{
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                      }}
+                    >
+                      <option value="">{t("hostsDialog.allInbounds")}</option>
+                      {inboundTags.map((tag) => (
+                        <option key={tag} value={tag}>
+                          {tag}
+                        </option>
+                      ))}
+                    </Select>
+                  </HStack>
 
-                  {/* INBOUND FILTER */}
-                  <Select
-                    mt={3}
-                    size="md"
-                    flexShrink={0}
-                    value={inboundFilter}
-                    onChange={(e) => setInboundFilter(e.target.value)}
-                  >
-                    <option value="">{t("hostsDialog.allInbounds")}</option>
-
-                    {inboundTags.map((tag) => (
-                      <option key={tag} value={tag}>
-                        {tag}
-                      </option>
-                    ))}
-                  </Select>
-
-                  {/* ADD BUTTON */}
                   <Button
                     mt={3}
                     w="full"

--- a/app/dashboard/src/components/hostsDialog/AddHostForm.tsx
+++ b/app/dashboard/src/components/hostsDialog/AddHostForm.tsx
@@ -1,4 +1,12 @@
-import { Box, Button, FormControl, FormLabel, HStack, Select, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  HStack,
+  Select,
+  VStack,
+} from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   proxyALPN,

--- a/app/dashboard/src/components/hostsDialog/HostRow.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostRow.tsx
@@ -52,7 +52,8 @@ type HostRowProps = {
 const HOST_KEY = "hosts";
 
 export const HostRow = memo(function HostRow(props: HostRowProps) {
-  const { register, control } = useFormContext<z.infer<typeof hostsFormSchema>>();
+  const { register, control } =
+    useFormContext<z.infer<typeof hostsFormSchema>>();
   const {
     index,
     hostId,
@@ -94,7 +95,7 @@ export const HostRow = memo(function HostRow(props: HostRowProps) {
       >
         <Box
           bg="white"
-          _dark={{ bg: "gray.800" }}
+          _dark={{ bg: "gray.700" }}
           borderRadius="12px"
           boxShadow="0 2px 8px rgba(0,0,0,0.08)"
           border="1px solid"

--- a/app/dashboard/src/components/hostsDialog/HostsList.tsx
+++ b/app/dashboard/src/components/hostsDialog/HostsList.tsx
@@ -1,10 +1,6 @@
-import { Button, Collapse, VStack, Text } from "@chakra-ui/react";
-import {
-  ChevronDownIcon,
-  PlusIcon as HeroIconPlusIcon,
-} from "@heroicons/react/24/outline";
-import { FC, useCallback, useMemo, useState } from "react";
-import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { VStack, Text } from "@chakra-ui/react";
+import { FC, useCallback, useMemo } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
@@ -15,8 +11,7 @@ import {
   proxyHostSecurity,
 } from "constants/Proxies";
 import { NodeType } from "contexts/NodesContext";
-import { AddHostForm, EMPTY_HOST } from "./AddHostForm";
-import { hostsFormSchema, hostItemSchema } from "./schema";
+import { hostsFormSchema } from "./schema";
 import { HostRow } from "./HostRow";
 
 type Props = {
@@ -37,68 +32,63 @@ export const HostsList: FC<Props> = ({
   inboundMap,
 }) => {
   const { t } = useTranslation();
+
   const form = useFormContext<z.infer<typeof hostsFormSchema>>();
+
   const { errors } = form.formState;
   const accordionErrors = errors.hosts;
-  const [isAddingHost, setIsAddingHost] = useState(false);
 
-  const { fields, replace } = useFieldArray({
+  const watchedHosts = useWatch({
     control: form.control,
     name: "hosts",
   });
 
-  const watchedHosts = useWatch({ control: form.control, name: "hosts" });
-
   const visibleIndexes = useMemo(() => {
     const query = search.trim().toLowerCase();
-    return fields
+
+    return (watchedHosts || [])
       .map((_, index) => index)
       .filter((index) => {
         const host = watchedHosts?.[index];
+
         if (!host) return false;
-        if (inboundFilter && host.inbound_tag !== inboundFilter) return false;
-        if (query && !(host.remark || "").toLowerCase().includes(query))
+
+        if (inboundFilter && host.inbound_tag !== inboundFilter) {
           return false;
+        }
+
+        if (query && !(host.remark || "").toLowerCase().includes(query)) {
+          return false;
+        }
+
         return true;
       });
-  }, [fields, watchedHosts, inboundFilter, search]);
-
-  const renumberOrders = useCallback(
-    (hosts: z.infer<typeof hostsFormSchema>["hosts"]) => {
-      return hosts.map((host, index) => ({ ...host, order: index }));
-    },
-    []
-  );
+  }, [watchedHosts, inboundFilter, search]);
 
   const setHosts = useCallback(
     (hosts: z.infer<typeof hostsFormSchema>["hosts"]) => {
-      replace(renumberOrders(hosts));
-    },
-    [renumberOrders, replace]
-  );
+      const renumbered = hosts.map((host, index) => ({
+        ...host,
+        order: index,
+      }));
 
-  const handleHostAdded = useCallback(
-    (host: z.infer<typeof hostItemSchema>) => {
-      const current = form.getValues("hosts") || [];
-      setHosts([
-        ...current,
-        {
-          ...EMPTY_HOST,
-          ...host,
-          order: current.length,
-        },
-      ]);
-      setIsAddingHost(false);
+      form.setValue("hosts", renumbered, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
     },
-    [form, setHosts]
+    [form]
   );
 
   const duplicateHost = useCallback(
     (index: number) => {
       const hosts = [...(form.getValues("hosts") || [])];
       const value = hosts[index];
+
       if (!value) return;
+
       hosts.splice(index + 1, 0, structuredClone(value));
+
       setHosts(hosts);
     },
     [form, setHosts]
@@ -107,15 +97,21 @@ export const HostsList: FC<Props> = ({
   const moveHostPosition = useCallback(
     (index: number, direction: "up" | "down") => {
       const visiblePos = visibleIndexes.indexOf(index);
+
       if (visiblePos < 0) return;
+
       const targetPos = direction === "up" ? visiblePos - 1 : visiblePos + 1;
+
       const targetIndex = visibleIndexes[targetPos];
+
       if (targetIndex === undefined) return;
 
       const hosts = [...(form.getValues("hosts") || [])];
+
       const tmp = hosts[index];
       hosts[index] = hosts[targetIndex];
       hosts[targetIndex] = tmp;
+
       setHosts(hosts);
     },
     [form, setHosts, visibleIndexes]
@@ -124,7 +120,9 @@ export const HostsList: FC<Props> = ({
   const removeHost = useCallback(
     (index: number) => {
       const hosts = [...(form.getValues("hosts") || [])];
+
       hosts.splice(index, 1);
+
       setHosts(hosts);
     },
     [form, setHosts]
@@ -140,35 +138,6 @@ export const HostsList: FC<Props> = ({
 
   return (
     <VStack w="full" align="stretch" spacing={3}>
-      <Button
-        w="full"
-        variant="outline"
-        leftIcon={<HeroIconPlusIcon width="20px" strokeWidth={2} />}
-        rightIcon={
-          <ChevronDownIcon
-            width="16px"
-            style={{
-              transform: isAddingHost ? "rotate(180deg)" : "rotate(0deg)",
-              transition: "transform 0.2s ease",
-            }}
-          />
-        }
-        onClick={() => setIsAddingHost((prev) => !prev)}
-      >
-        {t("hostsDialog.addNewHost")}
-      </Button>
-
-      <Collapse in={isAddingHost} animateOpacity>
-        <AddHostForm
-          inboundTags={inboundTags}
-          defaultInboundTag={inboundFilter || inboundTags[0] || ""}
-          bots={bots}
-          nodes={nodes}
-          inboundMap={inboundMap}
-          onAdded={handleHostAdded}
-        />
-      </Collapse>
-
       {visibleIndexes.length === 0 ? (
         <Text opacity={0.7} fontSize="sm" py={4} textAlign="center">
           {t("hostsDialog.notFound")}
@@ -176,12 +145,13 @@ export const HostsList: FC<Props> = ({
       ) : (
         visibleIndexes.map((index, visiblePos) => {
           const host = watchedHosts?.[index];
-          const field = fields[index];
-          if (!host || !field) return null;
+
+          if (!host) return null;
+
           return (
             <HostRow
-              key={field.id}
-              hostId={field.id}
+              key={`${index}-${host.remark || "host"}`}
+              hostId={`${index}`}
               index={index}
               inboundTag={host.inbound_tag}
               canMoveUp={visiblePos > 0}

--- a/app/dashboard/src/hooks/useBotSelectStyles.tsx
+++ b/app/dashboard/src/hooks/useBotSelectStyles.tsx
@@ -23,7 +23,7 @@ export const useBotSelectStyles = ({
   const textToken = useColorModeValue("gray.800", "white");
 
   const borderToken = useColorModeValue(
-    variant === "filter" ? "gray.600" : "gray.200",
+    variant === "filter" ? "gray.200" : "gray.200",
     "gray.600"
   );
 

--- a/app/dashboard/src/index.css
+++ b/app/dashboard/src/index.css
@@ -1,4 +1,30 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
+
+* {
+  box-sizing: border-box;
+  scrollbar-width: thin;
+  scrollbar-color: #c1c1c1 #f1f1f1;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #a8a8a8;
+}
+
 .bg-blue-animate {
   animation: blur-animate 200ms ease-in;
   backdrop-filter: blur(10px);
@@ -90,22 +116,28 @@ table thead th:last-of-type {
   border-bottom: 1px solid var(--chakra-colors-gray-600);
 }
 
-.react-datepicker-popper[data-placement^=bottom] .react-datepicker__triangle::after {
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle::after {
   border-top: none;
   border-bottom-color: var(--chakra-colors-white);
 }
 
-.react-datepicker-popper[data-placement^=bottom] .react-datepicker__triangle::before {
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle::before {
   top: -1px;
   border-bottom-color: var(--chakra-colors-gray-200);
 }
 
-.chakra-ui-dark .react-datepicker-popper[data-placement^=bottom] .react-datepicker__triangle::after {
+.chakra-ui-dark
+  .react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle::after {
   border-top: none;
   border-bottom-color: var(--chakra-colors-gray-700);
 }
 
-.chakra-ui-dark .react-datepicker-popper[data-placement^=bottom] .react-datepicker__triangle::before {
+.chakra-ui-dark
+  .react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle::before {
   top: -1px;
   border-bottom-color: var(--chakra-colors-gray-600);
 }
@@ -170,12 +202,17 @@ table thead th:last-of-type {
   color: var(--chakra-colors-gray-800) !important;
 }
 
-.react-datepicker__day--in-selecting-range:not(.react-datepicker__day--in-range) {
+.react-datepicker__day--in-selecting-range:not(
+    .react-datepicker__day--in-range
+  ) {
   border-radius: 0.3rem;
   background-color: var(--chakra-colors-primary-400) !important;
 }
 
-.chakra-ui-dark .react-datepicker__day--in-selecting-range:not(.react-datepicker__day--in-range) {
+.chakra-ui-dark
+  .react-datepicker__day--in-selecting-range:not(
+    .react-datepicker__day--in-range
+  ) {
   border-radius: 0.3rem;
   background-color: var(--chakra-colors-primary-400) !important;
 }
@@ -268,4 +305,4 @@ table thead th:last-of-type {
   align-items: center;
   justify-content: start;
   gap: 0.7rem;
-}/*# sourceMappingURL=index.css.map */
+} /*# sourceMappingURL=index.css.map */


### PR DESCRIPTION
### Доработала модалку настройки хостов:

- Увеличила ширину модалки - единообразно/одной ширины с другими модальными окнами.
- Добавила заголовок и подзаголовок-описание в шапку — теперь понятно, где находишься и что делает эта настройка.
- Пересобрала расположение: поиск и фильтр по inbound теперь в один ряд, кнопка "Добавить хост" — под ними, компактнее по высоте.
- Закрепила блок с кнопкой добавления хоста и полями поиска/фильтра сверху — не скроллится вместе со списком.
- Список хостов теперь скроллится отдельно от остальной формы
- Кнопка "Применить" закреплена внизу и всегда видна.
- Поправила баг с двойным скроллом (при долистывании списка до конца скроллилась ещё и страница за модалкой).

скриншоты, при необходимости, в чате к [задаче](https://yougile.com/team/9a0e05abf438/#NPVPN-1827)