### PR TITLE
NPVPN-1838: интроспекция памяти процесса панели

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,3 +185,11 @@ UVICORN_PORT = 8000
 # LOG_ACCESS_ENABLED=true
 # LOG_ACCESS_NOISE_PATHS=/metrics
 # LOG_SQL_SLOW_ENABLED=true
+
+## Диагностика памяти по требованию: включает sudo-only ручки GET /api/system/memory/heap
+## (снимок живых объектов кучи) и /api/system/memory/trace/* (tracemalloc). Обе операции
+## дорогие: обход кучи держит GIL. При выключенном флаге (по умолчанию) ручки не
+## регистрируются вовсе (404). Постоянные метрики памяти процесса (RSS, GC, именованные
+## пробы структур в /metrics) этим флагом не управляются и работают всегда. Флаг читается
+## на импорте — включение/выключение требует рестарта панели.
+# MEMORY_PROFILING_ENABLED=False

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -199,6 +199,10 @@ from app.utils.db_metrics import register as _register_db_metrics  # noqa: E402
 
 _register_db_metrics()
 
+from app.utils.memory_metrics import register as _register_memory_metrics  # noqa: E402
+
+_register_memory_metrics()
+
 from app import dashboard, jobs, routers, telegram  # noqa
 from app.routers import api_router  # noqa
 

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,11 +1,14 @@
 from fastapi import APIRouter
 
+from config import MEMORY_PROFILING_ENABLED
+
 from . import (
     admin,
     bot,
     core,
     home,
     managed,
+    memory,
     node,
     settings,
     subscription,
@@ -29,6 +32,9 @@ routers: list[APIRouter] = [
     user.router,
     home.router,
 ]
+
+if MEMORY_PROFILING_ENABLED:
+    routers.append(memory.router)  # type: ignore[has-type]
 
 for router in routers:
     api_router.include_router(router)

--- a/app/routers/memory.py
+++ b/app/routers/memory.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.models.admin import Admin
+from app.utils import responses
+from app.utils.memory_introspect import (
+    HeapScanBusy,
+    TracingNotStarted,
+    heap_snapshot,
+    trace_snapshot,
+    trace_start,
+    trace_stop,
+)
+
+router = APIRouter(tags=["System"], prefix="/api/system/memory", responses={401: responses._401})
+
+
+@router.get("/heap", responses={403: responses._403})
+def get_heap_snapshot(top: int = 30, admin: Admin = Depends(Admin.check_sudo_admin)):
+    """Срез живых объектов по типам. Держит GIL на время обхода кучи."""
+    try:
+        return heap_snapshot(top=top)
+    except HeapScanBusy:
+        raise HTTPException(status_code=409, detail="Heap scan already in progress")
+
+
+@router.post("/trace/start", responses={403: responses._403})
+def start_tracing(nframes: int = 1, admin: Admin = Depends(Admin.check_sudo_admin)):
+    """Запускает tracemalloc: видит аллокации, сделанные после этого вызова."""
+    return trace_start(nframes=nframes)
+
+
+@router.get("/trace/snapshot", responses={403: responses._403})
+def get_trace_snapshot(top: int = 30, admin: Admin = Depends(Admin.check_sudo_admin)):
+    """Топ мест аллокации и дельта к предыдущему снимку."""
+    try:
+        return trace_snapshot(top=top)
+    except TracingNotStarted:
+        raise HTTPException(status_code=409, detail="Tracing is not started")
+
+
+@router.post("/trace/stop", responses={403: responses._403})
+def stop_tracing(admin: Admin = Depends(Admin.check_sudo_admin)):
+    """Останавливает tracemalloc и освобождает трейсы."""
+    return trace_stop()

--- a/app/utils/memory_introspect.py
+++ b/app/utils/memory_introspect.py
@@ -1,0 +1,125 @@
+"""Диагностика памяти по требованию: срез кучи и tracemalloc (NPVPN-1838).
+
+Оба инструмента платные по CPU, поэтому вызываются только явно и живут за
+env-флагом MEMORY_PROFILING_ENABLED. Логика отделена от роутера: тесты панели
+не поднимают FastAPI-приложение.
+"""
+
+import gc
+import sys
+import threading
+import tracemalloc
+from collections import Counter
+
+_scan_lock = threading.Lock()
+_baseline = None
+
+
+class HeapScanBusy(Exception):
+    """Скан кучи уже выполняется."""
+
+
+class TracingNotStarted(Exception):
+    """tracemalloc не запущен."""
+
+
+def heap_snapshot(top: int = 30) -> dict:
+    """Срез живых объектов по типам.
+
+    Обходит всю кучу и держит GIL на время обхода — отсюда лок: два
+    параллельных скана удвоят паузу без всякой пользы.
+
+    Отдаёт топ по числу объектов (`top_by_count`) и отдельно топ по суммарным байтам
+    (`top_by_bytes`): тип с горсткой гигантских объектов (один список на 500 МБ) в
+    первый топ может не попасть вовсе, а это ровно тот случай, ради которого нужен
+    срез кучи.
+    """
+    top = max(1, min(int(top), 500))
+    if not _scan_lock.acquire(blocking=False):
+        raise HeapScanBusy
+
+    try:
+        objects = gc.get_objects()
+        counts: Counter[str] = Counter()
+        sizes: Counter[str] = Counter()
+        for obj in objects:
+            name = type(obj).__qualname__
+            counts[name] += 1
+            try:
+                sizes[name] += sys.getsizeof(obj)
+            except Exception:
+                continue
+
+        total = len(objects)
+        del objects
+
+        return {
+            "total_objects": total,
+            "top_by_count": [
+                {"type": name, "count": count, "bytes": sizes[name]} for name, count in counts.most_common(top)
+            ],
+            "top_by_bytes": [
+                {"type": name, "count": counts[name], "bytes": size} for name, size in sizes.most_common(top)
+            ],
+        }
+    finally:
+        _scan_lock.release()
+
+
+def trace_start(nframes: int = 1) -> dict:
+    """Запускает трейсинг аллокаций.
+
+    Видит только то, что аллоцировано после старта — для вопроса «что растёт»
+    это и нужно, а рестарт панели ради полной картины не оправдан.
+
+    Если трейсинг уже запущен, повторный `tracemalloc.start(nframes)` не меняет
+    действующую глубину трейсбека (эмпирически подтверждено: `get_traceback_limit()`
+    остаётся прежним). Поэтому в ответе всегда фактическая глубина
+    (`tracemalloc.get_traceback_limit()`), а не запрошенная — иначе вызывающий
+    получит цифру, которой в процессе нет.
+    """
+    global _baseline
+
+    nframes = max(1, min(int(nframes), 10))
+    if not tracemalloc.is_tracing():
+        tracemalloc.start(nframes)
+    _baseline = tracemalloc.take_snapshot()
+    return {"started": True, "nframes": tracemalloc.get_traceback_limit()}
+
+
+def trace_snapshot(top: int = 30) -> dict:
+    """Топ мест аллокации и дельта к предыдущему снимку."""
+    global _baseline
+
+    if not tracemalloc.is_tracing():
+        raise TracingNotStarted
+
+    top = max(1, min(int(top), 500))
+    snapshot = tracemalloc.take_snapshot()
+    statistics = snapshot.statistics("lineno")[:top]
+    result = {
+        "tracing": True,
+        "top": [{"location": str(stat.traceback), "size_bytes": stat.size, "count": stat.count} for stat in statistics],
+        "delta": [],
+    }
+
+    if _baseline is not None:
+        delta = snapshot.compare_to(_baseline, "lineno")[:top]
+        result["delta"] = [
+            {"location": str(stat.traceback), "size_bytes": stat.size_diff, "count": stat.count_diff} for stat in delta
+        ]
+
+    _baseline = snapshot
+    return result
+
+
+def trace_stop() -> dict:
+    """Останавливает трейсинг и освобождает накопленные трейсы."""
+    global _baseline
+
+    if not tracemalloc.is_tracing():
+        return {"stopped": False}
+
+    tracemalloc.stop()
+    _baseline = None
+    return {"stopped": True}

--- a/app/utils/memory_metrics.py
+++ b/app/utils/memory_metrics.py
@@ -1,0 +1,244 @@
+"""Экспортер памяти процесса панели для Prometheus (NPVPN-1838).
+
+Отвечает на вопрос «кто держит память» на двух дежурных уровнях:
+RSS по процессам (сам python + дочерний xray) и именованные пробы известных
+структур. Всё читается на скрейпе — фоновой работы нет, как в _DbPoolCollector.
+
+Существующий /api/system отдаёт psutil.virtual_memory(), то есть память ХОСТА;
+здесь речь именно о процессе.
+"""
+
+import gc
+import tracemalloc
+from collections.abc import Callable
+
+import psutil
+from prometheus_client import REGISTRY
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+
+from app import logger
+
+_process = psutil.Process()
+
+
+def _probe_nodes():
+    from app import xray
+
+    return len(xray.nodes), None
+
+
+def _probe_hosts(hosts=None):
+    """Число тегов инбаундов в хранилище хостов.
+
+    hosts — DictStorage: его keys()/values()/get() при пустом словаре вызывают
+    update_func и идут в БД. Поэтому len() (не переопределён) и dict.values()
+    несвязанным методом базового класса.
+    """
+    if hosts is None:
+        from app import xray
+
+        hosts = xray.hosts
+
+    return len(hosts), None
+
+
+def _probe_hosts_total(hosts=None):
+    """Суммарное число хостов по всем тегам."""
+    if hosts is None:
+        from app import xray
+
+        hosts = xray.hosts
+
+    return sum(len(v) for v in dict.values(hosts)), None
+
+
+def _probe_inbounds():
+    from app import xray
+
+    return len(xray.config.inbounds_by_tag), None
+
+
+def _probe_node_json_cache():
+    """Кэш пер-нодного JSON живёт не на модульном xray.config, а на копии конфига,
+    которую делает include_db_users() под каждую волну переподключения (см.
+    app/xray/config.py и app/xray/node_config.py). Слабую ссылку на кэш активной
+    волны хранит сам node_config, специально для этой пробы.
+    """
+    from app.xray import node_config
+
+    cache = node_config.get_current_node_json_cache()
+    if cache is None:
+        return None, None
+    # Копия словаря, а не cache._cache напрямую и не под cache._lock: build под
+    # этим локом длится секунды и исполняется на event loop, взятие лока
+    # подвесило бы весь HTTP панели на время сборки. dict.copy() атомарна
+    # относительно GIL.
+    entries = cache._cache.copy()
+    return len(entries), sum(len(v) for v in entries.values())
+
+
+def _probe_node_json_cache_builds():
+    """Кумулятивный счётчик билдов (не сбрасывается со сменой волны, в отличие от
+    build_count на экземпляре кэша) — поэтому не зависит от того, жива ли текущая
+    волна: репортит значение всегда, иначе метрика роста пропадала бы из графика
+    в каждом промежутке между волнами.
+    """
+    from app.xray import node_config
+
+    return node_config.get_node_json_cache_cumulative_builds(), None
+
+
+def _probe_connecting_nodes():
+    from app.xray import operations
+
+    return len(operations._connecting_nodes), None
+
+
+def _probe_connecting_started_at():
+    from app.xray import operations
+
+    return len(operations._connecting_started_at), None
+
+
+def _probe_log_buffers():
+    from app import xray
+
+    return len(xray.core._temp_log_buffers), None
+
+
+def _probe_logs_buffer():
+    from app import xray
+
+    return len(xray.core._logs_buffer), None
+
+
+PROBES: dict[str, Callable[[], tuple[int | None, int | None]]] = {
+    "xray.nodes": _probe_nodes,
+    "xray.hosts": _probe_hosts,
+    "xray.hosts.entries": _probe_hosts_total,
+    "xray.config.inbounds": _probe_inbounds,
+    "node_json_cache": _probe_node_json_cache,
+    "node_json_cache.builds": _probe_node_json_cache_builds,
+    "xray.connecting_nodes": _probe_connecting_nodes,
+    "xray.connecting_started_at": _probe_connecting_started_at,
+    "xray.core.log_buffers": _probe_log_buffers,
+    "xray.core.logs_buffer": _probe_logs_buffer,
+}
+
+
+class _MemoryCollector:
+    """Читает память процессов, статистику GC и пробы структур на каждом скрейпе."""
+
+    def describe(self):
+        # Без describe() prometheus_client вызывает collect() прямо при
+        # регистрации — то есть на старте приложения, когда xray ещё не поднят.
+        return []
+
+    def collect(self):
+        rss = GaugeMetricFamily(
+            "panel_process_memory_rss_bytes",
+            "Resident memory of the panel process and its children",
+            labels=["process"],
+        )
+        vms = GaugeMetricFamily(
+            "panel_process_memory_vms_bytes",
+            "Virtual memory of the panel process and its children",
+            labels=["process"],
+        )
+        try:
+            info = _process.memory_info()
+            rss.add_metric(["panel"], info.rss)
+            vms.add_metric(["panel"], info.vms)
+        except Exception as exc:
+            logger.warning("[metrics] failed to read process memory: %s", exc)
+
+        child_rss = 0
+        child_vms = 0
+        try:
+            for child in _process.children(recursive=True):
+                try:
+                    child_info = child.memory_info()
+                except psutil.Error:
+                    continue
+                child_rss += child_info.rss
+                child_vms += child_info.vms
+            rss.add_metric(["xray"], child_rss)
+            vms.add_metric(["xray"], child_vms)
+        except Exception as exc:
+            logger.warning("[metrics] failed to read children memory: %s", exc)
+
+        yield rss
+        yield vms
+
+        # panel_gc_*_total монотонно растут — Counter, а не Gauge. CounterMetricFamily
+        # сам добавляет суффикс _total к имени, поэтому здесь имя передаётся без него:
+        # иначе на выходе /metrics получится panel_gc_collections_total_total.
+        collections = CounterMetricFamily(
+            "panel_gc_collections", "GC collections per generation", labels=["generation"]
+        )
+        collected = CounterMetricFamily("panel_gc_collected", "Objects collected per generation", labels=["generation"])
+        uncollectable = CounterMetricFamily(
+            "panel_gc_uncollectable", "Uncollectable objects per generation", labels=["generation"]
+        )
+        try:
+            for generation, stats in enumerate(gc.get_stats()):
+                collections.add_metric([str(generation)], stats.get("collections", 0))
+                collected.add_metric([str(generation)], stats.get("collected", 0))
+                uncollectable.add_metric([str(generation)], stats.get("uncollectable", 0))
+        except Exception as exc:
+            logger.warning("[metrics] failed to read gc stats: %s", exc)
+
+        yield collections
+        yield collected
+        yield uncollectable
+
+        # Уровень 0 не управляется MEMORY_PROFILING_ENABLED — работает всегда, поэтому
+        # именно здесь, а не за флагом, нужен признак «tracemalloc сейчас пишет трейсы»:
+        # иначе забытый после инцидента trace/start (никто не позвал trace/stop) будет
+        # держать overhead молча — и никто не узнает, что причина роста RSS не в утечке,
+        # а в самом измерителе.
+        tracing = GaugeMetricFamily(
+            "panel_memory_tracing_enabled", "Whether tracemalloc is currently tracing allocations (1/0)"
+        )
+        try:
+            tracing.add_metric([], 1 if tracemalloc.is_tracing() else 0)
+        except Exception as exc:
+            logger.warning("[metrics] failed to read tracemalloc state: %s", exc)
+
+        yield tracing
+
+        items = GaugeMetricFamily(
+            "panel_memory_probe_items", "Number of elements held by a known structure", labels=["structure"]
+        )
+        sizes = GaugeMetricFamily(
+            "panel_memory_probe_bytes", "Approximate bytes held by a known structure", labels=["structure"]
+        )
+        for name, probe in list(PROBES.items()):
+            try:
+                probe_items, probe_bytes = probe()
+            except Exception as exc:
+                # Диагностика не имеет права ронять скрейп: /metrics нужен
+                # именно тогда, когда что-то уже сломалось.
+                logger.warning("[metrics] memory probe %s failed: %s", name, exc)
+                continue
+            if probe_items is not None:
+                items.add_metric([name], probe_items)
+            if probe_bytes is not None:
+                sizes.add_metric([name], probe_bytes)
+
+        yield items
+        yield sizes
+
+
+_registered = False
+
+
+def register():
+    global _registered
+    if _registered:
+        return
+    try:
+        REGISTRY.register(_MemoryCollector())
+        _registered = True
+    except Exception as exc:
+        logger.warning("[metrics] failed to register memory collector: %s", exc)

--- a/app/xray/node_config.py
+++ b/app/xray/node_config.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import threading
+import weakref
 from collections.abc import Callable, Collection, Iterable
 
 from app.xray.bs_limit import strip_blocked_clients
@@ -99,6 +100,7 @@ class _NodeJsonCache:
         self._cache: dict[tuple, str] = {}
         self._lock = threading.Lock()
         self.build_count = 0
+        _set_current_cache(self)
 
     def __deepcopy__(self, memo):
         # XRayConfig.copy() == deepcopy(self); the per-node config copies made during a
@@ -121,10 +123,48 @@ class _NodeJsonCache:
             js = self._build(self._base, node_inbound_tags, cascade_kwargs, blocked_user_ids)
             self._cache[key] = js
             self.build_count += 1
+            _bump_cumulative_build_count()
             return js
 
 
 _attach_lock = threading.Lock()
+
+# Слабая ссылка на кэш активной волны и кумулятивный счётчик билдов — для
+# проб памяти (NPVPN-1838). Слабая ссылка нужна категорически: обычная
+# модульная ссылка запинила бы полную копию волнового конфига со всеми
+# юзерами навсегда, и сам инструмент измерения стал бы утечкой.
+_current_cache_ref: weakref.ReferenceType[_NodeJsonCache] | None = None
+_cumulative_build_count = 0
+_cumulative_build_count_lock = threading.Lock()
+
+
+def _set_current_cache(cache: _NodeJsonCache) -> None:
+    global _current_cache_ref
+    _current_cache_ref = weakref.ref(cache)
+
+
+def _bump_cumulative_build_count() -> None:
+    global _cumulative_build_count
+    with _cumulative_build_count_lock:
+        _cumulative_build_count += 1
+
+
+def get_current_node_json_cache() -> _NodeJsonCache | None:
+    """Кэш пер-нодного конфига активной (последней построенной) волны, если он ещё жив.
+
+    Возвращает None, если волна ещё не строилась или объект уже собран GC —
+    вызывающий (проба памяти) должен в этом случае просто не эмитить метрику.
+    """
+    return _current_cache_ref() if _current_cache_ref is not None else None
+
+
+def get_node_json_cache_cumulative_builds() -> int:
+    """Кумулятивное число билдов пер-нодного конфига за всё время жизни процесса.
+
+    В отличие от `_NodeJsonCache.build_count` (живёт на экземпляре и обнуляется с
+    каждой новой волной), этот счётчик не сбрасывается — им можно мерить рост.
+    """
+    return _cumulative_build_count
 
 
 def node_config_json(

--- a/config.py
+++ b/config.py
@@ -20,6 +20,10 @@ DASHBOARD_PATH = config("DASHBOARD_PATH", default="/dashboard/")
 DEBUG = config("DEBUG", default=False, cast=bool)
 DOCS = config("DOCS", default=False, cast=bool)
 
+# NPVPN-1838: ручки диагностики памяти (обход кучи, tracemalloc) платные по CPU,
+# поэтому выключены по умолчанию. Метрики уровня процесса флагом не управляются.
+MEMORY_PROFILING_ENABLED = config("MEMORY_PROFILING_ENABLED", default=False, cast=bool)
+
 ALLOWED_ORIGINS = config("ALLOWED_ORIGINS", default="*").split(",")
 
 VITE_BASE_API = (

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -138,8 +138,6 @@ app/routers/__init__.py:0: error: Cannot determine type of "router"  [has-type]
 app/routers/__init__.py:0: error: Cannot determine type of "router"  [has-type]
 app/routers/__init__.py:0: error: Cannot determine type of "router"  [has-type]
 app/routers/__init__.py:0: error: Cannot determine type of "router"  [has-type]
-app/utils/system.py:0: error: Library stubs not installed for "psutil"  [import-untyped]
-app/utils/system.py:0: note: Hint: "python3 -m pip install types-psutil"
 app/utils/system.py:0: error: Incompatible types in assignment (expression has type "None", variable has type "int")  [assignment]
 app/utils/system.py:0: error: Incompatible types in assignment (expression has type "None", variable has type "int")  [assignment]
 app/utils/system.py:0: error: Incompatible types in assignment (expression has type "None", variable has type "int")  [assignment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ module = [
     "xray_api.*",
     "apscheduler.*",
     "prometheus_fastapi_instrumentator.*",
+    "psutil.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/test_memory_introspect.py
+++ b/tests/test_memory_introspect.py
@@ -1,0 +1,125 @@
+"""Тесты диагностики памяти по требованию (NPVPN-1838)."""
+
+import tracemalloc
+
+import pytest
+
+from app.utils import memory_introspect
+
+
+@pytest.fixture(autouse=True)
+def _stop_tracing():
+    yield
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+    memory_introspect._baseline = None
+
+
+def test_heap_snapshot_reports_types():
+    result = memory_introspect.heap_snapshot(top=5)
+
+    assert result["total_objects"] > 0
+    assert len(result["top_by_count"]) <= 5
+    entry = result["top_by_count"][0]
+    assert set(entry) == {"type", "count", "bytes"}
+    assert entry["count"] > 0
+
+
+def test_heap_snapshot_reports_top_by_bytes():
+    """Тип с горсткой огромных объектов не попал бы в top_by_count, но обязан
+    появиться в top_by_bytes — ради этого случая и нужен уровень 2."""
+
+    class _HugeBallast:
+        def __init__(self):
+            self.payload = "z" * (2 * 1024 * 1024)
+
+    ballast = [_HugeBallast() for _ in range(3)]
+
+    result = memory_introspect.heap_snapshot(top=2000)
+
+    # __qualname__ включает путь вложенности (test_.....<locals>._HugeBallast).
+    by_bytes = {entry["type"]: entry for entry in result["top_by_bytes"]}
+    matches = [entry for name, entry in by_bytes.items() if name.endswith("_HugeBallast")]
+    assert matches, by_bytes.keys()
+    entry = matches[0]
+    assert entry["count"] == 3
+    assert entry["bytes"] > 0
+    del ballast
+
+
+def test_heap_snapshot_clamps_top():
+    result = memory_introspect.heap_snapshot(top=-5)
+    assert len(result["top_by_count"]) <= 1
+
+    result = memory_introspect.heap_snapshot(top=10**9)
+    assert len(result["top_by_count"]) <= 500
+
+
+def test_heap_snapshot_rejects_parallel_scan():
+    memory_introspect._scan_lock.acquire()
+    try:
+        with pytest.raises(memory_introspect.HeapScanBusy):
+            memory_introspect.heap_snapshot(top=5)
+    finally:
+        memory_introspect._scan_lock.release()
+
+
+def test_trace_snapshot_requires_started_tracing():
+    with pytest.raises(memory_introspect.TracingNotStarted):
+        memory_introspect.trace_snapshot(top=5)
+
+
+def test_trace_start_snapshot_stop_cycle():
+    started = memory_introspect.trace_start(nframes=1)
+    assert started["started"] is True
+    assert tracemalloc.is_tracing()
+
+    ballast = ["x" * 1024 for _ in range(1000)]
+
+    snapshot = memory_introspect.trace_snapshot(top=5)
+    assert snapshot["tracing"] is True
+    assert snapshot["top"]
+    assert set(snapshot["top"][0]) == {"location", "size_bytes", "count"}
+
+    assert len(ballast) == 1000
+
+    stopped = memory_introspect.trace_stop()
+    assert stopped["stopped"] is True
+    assert not tracemalloc.is_tracing()
+
+
+def test_trace_snapshot_reports_delta_after_first_call():
+    """Дельта не просто непустая (compare_to почти всегда что-то отдаёт), а содержит
+    запись с положительным size_diff в строке, где выделен балласт — иначе тест
+    не поймает регресс, при котором дельта считается неправильно."""
+    memory_introspect.trace_start(nframes=1)
+    memory_introspect.trace_snapshot(top=50)
+
+    ballast = ["y" * 2048 for _ in range(1000)]  # noqa: F841 — аллокация нужна как есть
+
+    second = memory_introspect.trace_snapshot(top=50)
+    assert second["delta"]
+    this_file = __file__
+    matching = [entry for entry in second["delta"] if this_file in entry["location"] and entry["size_bytes"] > 0]
+    assert matching, second["delta"]
+
+
+def test_trace_snapshot_clamps_top():
+    memory_introspect.trace_start(nframes=1)
+
+    snapshot = memory_introspect.trace_snapshot(top=-5)
+    assert len(snapshot["top"]) <= 1
+
+
+def test_trace_stop_without_start_is_noop():
+    assert memory_introspect.trace_stop() == {"stopped": False}
+
+
+def test_trace_start_reports_actual_depth_when_already_tracing():
+    memory_introspect.trace_start(nframes=1)
+    assert tracemalloc.get_traceback_limit() == 1
+
+    restarted = memory_introspect.trace_start(nframes=5)
+
+    assert restarted["nframes"] == tracemalloc.get_traceback_limit()
+    assert restarted["nframes"] == 1

--- a/tests/test_memory_metrics.py
+++ b/tests/test_memory_metrics.py
@@ -1,0 +1,200 @@
+"""Тесты экспортера памяти панели (NPVPN-1838)."""
+
+import tracemalloc
+
+from app.utils import memory_metrics
+
+
+def _collect(collector):
+    return {m.name: m for m in collector.collect()}
+
+
+def test_process_metrics_are_exported():
+    collector = memory_metrics._MemoryCollector()
+    families = _collect(collector)
+
+    rss = families["panel_process_memory_rss_bytes"]
+    processes = {tuple(s.labels.values()) for s in rss.samples}
+    assert ("panel",) in processes
+    assert all(s.value >= 0 for s in rss.samples)
+
+
+def _samples_by_name(collector):
+    samples = {}
+    for family in collector.collect():
+        for sample in family.samples:
+            samples.setdefault(sample.name, []).append(sample)
+    return samples
+
+
+def test_gc_metrics_are_exported():
+    """gc-метрики — Counter (не Gauge): монотонно растут. CounterMetricFamily сам
+    добавляет суффикс _total, поэтому здесь сверяется итоговое имя сэмпла на выходе
+    /metrics, а не имя семейства (у него суффикса нет)."""
+    collector = memory_metrics._MemoryCollector()
+    samples = _samples_by_name(collector)
+
+    collections = samples["panel_gc_collections_total"]
+    generations = {s.labels["generation"] for s in collections}
+    assert generations == {"0", "1", "2"}
+
+
+def test_gc_metrics_are_counters_not_gauges():
+    """Регресс-тест на пункт 5 ревью: имена семплов не должны разъехаться при
+    смене GaugeMetricFamily -> CounterMetricFamily (двойной суффикс _total_total
+    или его отсутствие — оба варианта сломали бы Grafana-дашборд и запросы)."""
+    collector = memory_metrics._MemoryCollector()
+    samples = _samples_by_name(collector)
+
+    for name in ("panel_gc_collections_total", "panel_gc_collected_total", "panel_gc_uncollectable_total"):
+        assert name in samples
+        assert f"{name}_total" not in samples
+
+
+def test_probe_values_are_exported(monkeypatch):
+    monkeypatch.setitem(memory_metrics.PROBES, "fake.structure", lambda: (7, 1024))
+
+    families = _collect(memory_metrics._MemoryCollector())
+
+    items = {s.labels["structure"]: s.value for s in families["panel_memory_probe_items"].samples}
+    sizes = {s.labels["structure"]: s.value for s in families["panel_memory_probe_bytes"].samples}
+    assert items["fake.structure"] == 7
+    assert sizes["fake.structure"] == 1024
+
+
+def test_probe_without_bytes_emits_only_items(monkeypatch):
+    monkeypatch.setitem(memory_metrics.PROBES, "items.only", lambda: (3, None))
+
+    families = _collect(memory_metrics._MemoryCollector())
+
+    items = {s.labels["structure"]: s.value for s in families["panel_memory_probe_items"].samples}
+    sizes = {s.labels["structure"] for s in families["panel_memory_probe_bytes"].samples}
+    assert items["items.only"] == 3
+    assert "items.only" not in sizes
+
+
+def test_failing_probe_does_not_break_scrape(monkeypatch):
+    def boom():
+        raise RuntimeError("structure renamed")
+
+    monkeypatch.setitem(memory_metrics.PROBES, "broken", boom)
+    monkeypatch.setitem(memory_metrics.PROBES, "healthy", lambda: (1, None))
+
+    families = _collect(memory_metrics._MemoryCollector())
+
+    items = {s.labels["structure"]: s.value for s in families["panel_memory_probe_items"].samples}
+    assert items["healthy"] == 1
+    assert "broken" not in items
+
+
+def test_tracing_gauge_reflects_state_when_not_tracing():
+    assert not tracemalloc.is_tracing()
+
+    families = _collect(memory_metrics._MemoryCollector())
+
+    gauge = families["panel_memory_tracing_enabled"]
+    assert [s.value for s in gauge.samples] == [0]
+
+
+def test_tracing_gauge_reflects_state_when_tracing():
+    tracemalloc.start()
+    try:
+        families = _collect(memory_metrics._MemoryCollector())
+        gauge = families["panel_memory_tracing_enabled"]
+        assert [s.value for s in gauge.samples] == [1]
+    finally:
+        tracemalloc.stop()
+
+    assert not tracemalloc.is_tracing()
+
+
+def test_node_json_cache_probes_read_live_wave_cache():
+    """Регресс на CRITICAL-находку: раньше пробы читали getattr(xray.config,
+    "_node_json_cache", None), где кэша никогда не было (он живёт на копии
+    конфига волны, а не на модульном xray.config). Теперь читают через
+    node_config.get_current_node_json_cache()."""
+    from app.xray import node_config
+
+    cache = node_config._NodeJsonCache(base_config=object(), build=lambda *a, **kw: "x" * 10)
+    cache.get(["TAG"], {}, [])
+
+    items, size_bytes = memory_metrics._probe_node_json_cache()
+    assert items == 1
+    assert size_bytes == 10
+
+    builds, _ = memory_metrics._probe_node_json_cache_builds()
+    assert builds >= 1
+
+
+def test_node_json_cache_probe_is_none_without_live_cache(monkeypatch):
+    from app.xray import node_config
+
+    monkeypatch.setattr(node_config, "_current_cache_ref", None)
+
+    items, size_bytes = memory_metrics._probe_node_json_cache()
+    assert items is None
+    assert size_bytes is None
+
+
+def test_node_json_cache_probe_does_not_pin_dead_cache():
+    """Слабая ссылка: когда кэш волны собран GC, проба не эмитит метрику вместо
+    того, чтобы держать полную копию конфига в памяти вечно."""
+    import gc
+
+    from app.xray import node_config
+
+    def _make_and_drop():
+        node_config._NodeJsonCache(base_config=object(), build=lambda *a, **kw: "x")
+
+    _make_and_drop()
+    gc.collect()
+
+    assert node_config.get_current_node_json_cache() is None
+    items, size_bytes = memory_metrics._probe_node_json_cache()
+    assert items is None
+    assert size_bytes is None
+
+
+def test_hosts_probe_does_not_trigger_db_update():
+    """DictStorage.values()/keys() при пустом storage лезут в БД.
+
+    Проба обязана читать хосты в обход этого — иначе каждый скрейп Prometheus
+    оборачивается запросом в MySQL.
+    """
+    from app.utils.store import DictStorage
+
+    calls = []
+
+    def update_func(storage):
+        calls.append(1)
+        storage["INBOUND"] = [{"remark": "x"}]
+
+    hosts = DictStorage(update_func)
+
+    items, _ = memory_metrics._probe_hosts(hosts)
+
+    assert calls == []
+    assert items == 0
+
+
+def test_register_is_idempotent(monkeypatch):
+    """Второй register() не должен трогать глобальный REGISTRY.
+
+    Мокаем сам REGISTRY.register: реальная повторная регистрация подняла бы
+    ValueError про дублирующиеся имена метрик, и тест проверял бы обработку
+    ошибки вместо идемпотентности.
+    """
+    calls = []
+    monkeypatch.setattr(memory_metrics.REGISTRY, "register", calls.append)
+    monkeypatch.setattr(memory_metrics, "_registered", False)
+
+    memory_metrics.register()
+    memory_metrics.register()
+
+    assert len(calls) == 1
+
+
+def test_collector_describe_is_empty():
+    """describe() должен быть пустым: иначе prometheus_client вызовет collect()
+    прямо в момент регистрации на старте приложения, когда xray ещё не поднят."""
+    assert list(memory_metrics._MemoryCollector().describe()) == []


### PR DESCRIPTION
## Что и зачем

Память контейнера панели растёт, а понять, кто её держит, было нечем: `GET /api/system` отдаёт `psutil.virtual_memory()`, то есть память **хоста**, а не процесса; `/metrics` — только HTTP-латентность; cadvisor меряет контейнер снаружи и внутрь процесса не смотрит. Каждый инцидент приходилось разбирать гаданием по коду.

Добавлена постоянная возможность увидеть, чем занята память процесса, на трёх уровнях детализации. Дежурный уровень работает всегда и ничего не стоит; всё, за что нужно платить процессорным временем, живёт за env-флагом и по умолчанию выключено.

## Изменения

- `app/utils/memory_metrics.py` — Prometheus-коллектор, читающий состояние на скрейпе (фоновой работы нет, паттерн взят из `db_metrics.py`):
  - RSS/VMS отдельно по python-процессу (`process="panel"`) и по дочерним (`process="xray"`) — сразу видно, чья это память;
  - счётчики GC по поколениям;
  - `panel_memory_tracing_enabled` — признак того, что кто-то оставил включённым tracemalloc;
  - реестр именованных проб известных структур: кэш пер-нодных конфигов, реестр нод, хосты, инбаунды, словари подключения нод, лог-буферы ядра.
- `app/utils/memory_introspect.py` — диагностика по требованию: срез живых объектов по типам (топ и по числу, и по байтам) и tracemalloc со стартом в рантайме и дельтой между снимками.
- `app/routers/memory.py` — четыре sudo-only эндпоинта поверх неё, регистрируются условно.
- `config.py` — `MEMORY_PROFILING_ENABLED` (default `False`), `.env.example` — его описание.
- `app/xray/node_config.py` — слабая ссылка на кэш конфигов активной волны и кумулятивный счётчик билдов, чтобы пробы вообще могли его увидеть.
- Тесты: 325 проходящих (было 309). Расшиты 5 новых ошибок mypy, попутно ушли 2 существующие — baseline уменьшился.

## Заметки для ревью

- **Почему weakref, а не обычная ссылка.** `_NodeJsonCache` живёт не на модульном `xray.config`, а на **копии** конфига из `include_db_users()` (`app/xray/config.py:415`). Первая версия пробы искала кэш на `xray.config` и поэтому не смогла бы измерить ничего никогда — притом что кэш конфигов и есть главный подозреваемый задачи. Чинить это сильной модульной ссылкой нельзя: она запинила бы в памяти полную копию конфига со всеми юзерами, то есть сам измеритель стал бы утечкой в сотни мегабайт.
- **Почему проба читает кэш через `.copy()`, а не под `cache._lock`.** Под этим локом идёт сборка конфига, которая длится секундами, а `collect()` исполняется на event loop — взятие лока подвесило бы весь HTTP панели на время сборки.
- **Почему `xray.hosts` читается через `len()` и `dict.values(hosts)`.** Это `DictStorage`, у которого `values()`/`keys()`/`get()` при пустом словаре идут в MySQL. Обычное `hosts.values()` означало бы запрос в БД на каждый скрейп Prometheus. Есть тест ровно на это.
- **Выключенный флаг = ручек нет**, а не 403: роутер не попадает в список и не появляется даже в OpenAPI. Флаг читается на импорте, поэтому выключение требует рестарта панели.
- **Кардинальность.** Места аллокации (`file:line`) и имена типов уходят только в тела HTTP-ответов и никогда в метрики — как значения лейблов это неограниченная кардинальность.
- **Что осталось проверить на стенде** (в pytest невозможно — `conftest.py` подменяет пакет `app` заглушкой, поднять приложение нельзя): коды ответов эндпоинтов 404 при выключенном флаге, 401 без токена, 403 без sudo, 409 при параллельном скане, и живой вид `/metrics`.
- **Порядок выкатки:** сначала этот PR, потом парный в боте (npvpn/telegram_bot) — там Grafana-панели, которые без этих метрик будут пустыми.
- Осознанно не сделано: py-spy/memray в образ, починка найденных подозреваемых (это измерение, а не оптимизация), лимит памяти контейнеру.
