### PR TITLE
NPVPN-1847/bs-traffic-info

### DIFF
--- a/templates/sub/expired.html
+++ b/templates/sub/expired.html
@@ -52,9 +52,17 @@
             }; 
               return colors[this.user.status.value] || '#7b7b7b'; 
           },
-          get trafficText() {
-            const used = bytesFormat(this.user.used_traffic);
-            const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
+          // get trafficText() {
+          //   const used = bytesFormat(this.user.used_traffic);
+          //   const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
+          //   return `${used}/${limit}`;
+          // },
+          get isBsActive() {
+            return this.user.bs_monthly_limit_total > 0;
+          },
+          get bsTrafficText() {
+            const used = bytesFormat(this.user.bs_monthly_used);
+            const limit = bytesFormat(this.user.bs_monthly_limit_total);
             return `${used}/${limit}`;
           },
           get expirationText() {
@@ -114,9 +122,9 @@
             <span class="tariff-info" :style="{ color: statusColor }" x-text="statusText"></span>
           </div>
 
-          <div class="info-row">
-            <span class="text-[#7b7b7b] tariff-info">Трафик</span>
-            <span class="tariff-info" x-text="trafficText"></span>
+          <div class="info-row" x-show="isBsActive">
+            <span class="text-[#7b7b7b] tariff-info">Трафик (белый список)</span>
+            <span class="tariff-info" x-text="bsTrafficText"></span>
           </div>
 
           <div class="info-row">

--- a/templates/sub/expired.html
+++ b/templates/sub/expired.html
@@ -52,11 +52,6 @@
             }; 
               return colors[this.user.status.value] || '#7b7b7b'; 
           },
-          // get trafficText() {
-          //   const used = bytesFormat(this.user.used_traffic);
-          //   const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
-          //   return `${used}/${limit}`;
-          // },
           get isBsActive() {
             return this.user.bs_monthly_limit_total > 0;
           },

--- a/templates/sub/index.html
+++ b/templates/sub/index.html
@@ -37,7 +37,9 @@
         used_traffic: "{{ user.used_traffic or 0 }}",
         data_limit: "{% if not user.data_limit %}0{% else %}{{ user.data_limit }}{% endif %}",
         expire: "{% if not user.expire %}0{% else %}{{ user.expire }}{% endif %}",
-        reset_strategy: "{{ user.data_limit_reset_strategy.value }}"
+        reset_strategy: "{{ user.data_limit_reset_strategy.value }}",
+        bs_monthly_used: "{{ user.bs_monthly_used or 0 }}",
+        bs_monthly_limit_total: "{% if not user.bs_monthly_limit_total %}0{% else %}{{ user.bs_monthly_limit_total }}{% endif %}"
       };
 
       function bytesFormat(bytes, decimals = 2) {
@@ -204,9 +206,17 @@
             };
             return classes[this.user.status.value] || 'text-gray-500';
           },
-          get trafficText() {
-            const used = bytesFormat(this.user.used_traffic);
-            const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
+          // get trafficText() {
+          //   const used = bytesFormat(this.user.used_traffic);
+          //   const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
+          //   return `${used}/${limit}`;
+          // },
+          get isBsActive() {
+            return this.user.bs_monthly_limit_total > 0;
+          },
+          get bsTrafficText() {
+            const used = bytesFormat(this.user.bs_monthly_used);
+            const limit = bytesFormat(this.user.bs_monthly_limit_total);
             return `${used}/${limit}`;
           },
           get expirationText() {
@@ -631,9 +641,9 @@ sudo apt install ./Happ.linux.x64.deb
                   <span class="text-[#7b7b7b] tariff-info">Статус</span>
                   <span class="tariff-info" :class="statusClass" x-text="statusText"></span>
                 </div>
-                <div class="flex justify-between items-center">
-                  <span class="text-[#7b7b7b] tariff-info">Трафик</span>
-                  <span class="tariff-info" x-text="trafficText"></span>
+                <div class="flex justify-between items-center" x-show="isBsActive">
+                  <span class="text-[#7b7b7b] tariff-info">Трафик (белый список)</span>
+                  <span class="tariff-info" x-text="bsTrafficText"></span>
                 </div>
                 <div class="flex justify-between items-center">
                   <span class="text-[#7b7b7b] tariff-info">Действует до</span>

--- a/templates/sub/index.html
+++ b/templates/sub/index.html
@@ -206,11 +206,6 @@
             };
             return classes[this.user.status.value] || 'text-gray-500';
           },
-          // get trafficText() {
-          //   const used = bytesFormat(this.user.used_traffic);
-          //   const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
-          //   return `${used}/${limit}`;
-          // },
           get isBsActive() {
             return this.user.bs_monthly_limit_total > 0;
           },

--- a/templates/sub/limited.html
+++ b/templates/sub/limited.html
@@ -122,11 +122,6 @@
             };
             return colors[this.user.status.value] || '#7b7b7b';
           },
-          // get trafficText() {
-          //   const used = bytesFormat(this.user.used_traffic);
-          //   const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
-          //   return `${used} / ${limit}`;
-          // },
           get isBsActive() {
             return this.user.bs_monthly_limit_total > 0;
           },

--- a/templates/sub/limited.html
+++ b/templates/sub/limited.html
@@ -122,10 +122,18 @@
             };
             return colors[this.user.status.value] || '#7b7b7b';
           },
-          get trafficText() {
-            const used = bytesFormat(this.user.used_traffic);
-            const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
-            return `${used} / ${limit}`;
+          // get trafficText() {
+          //   const used = bytesFormat(this.user.used_traffic);
+          //   const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
+          //   return `${used} / ${limit}`;
+          // },
+          get isBsActive() {
+            return this.user.bs_monthly_limit_total > 0;
+          },
+          get bsTrafficText() {
+            const used = bytesFormat(this.user.bs_monthly_used);
+            const limit = bytesFormat(this.user.bs_monthly_limit_total);
+            return `${used}/${limit}`;
           },
           get expirationText() {
             if (this.user.expire == 0) return 'Никогда';
@@ -277,9 +285,9 @@
               <span class="tariff-info" :style="{ color: statusColor }" x-text="statusText"></span>
             </div>
 
-            <div class="info-row">
-              <span class="text-[#7b7b7b] tariff-info">Трафик</span>
-              <span class="tariff-info" x-text="trafficText"></span>
+            <div class="info-row" x-show="isBsActive">
+              <span class="text-[#7b7b7b] tariff-info">Трафик (белый список)</span>
+              <span class="tariff-info" x-text="bsTrafficText"></span>
             </div>
 
             <div class="info-row">

--- a/templates/sub/revoked.html
+++ b/templates/sub/revoked.html
@@ -51,11 +51,6 @@
             };
             return colors[this.user.status.value] || '#7b7b7b';
           },
-          // get trafficText() {
-          //   const used = bytesFormat(this.user.used_traffic);
-          //   const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
-          //   return `${used}/${limit}`;
-          // },
           get isBsActive() {
             return this.user.bs_monthly_limit_total > 0;
           },

--- a/templates/sub/revoked.html
+++ b/templates/sub/revoked.html
@@ -51,9 +51,17 @@
             };
             return colors[this.user.status.value] || '#7b7b7b';
           },
-          get trafficText() {
-            const used = bytesFormat(this.user.used_traffic);
-            const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
+          // get trafficText() {
+          //   const used = bytesFormat(this.user.used_traffic);
+          //   const limit = this.user.data_limit > 0 ? bytesFormat(this.user.data_limit) : 'Безлимит';
+          //   return `${used}/${limit}`;
+          // },
+          get isBsActive() {
+            return this.user.bs_monthly_limit_total > 0;
+          },
+          get bsTrafficText() {
+            const used = bytesFormat(this.user.bs_monthly_used);
+            const limit = bytesFormat(this.user.bs_monthly_limit_total);
             return `${used}/${limit}`;
           },
           get expirationText() {
@@ -103,9 +111,9 @@
             <span class="tariff-info" :style="{ color: statusColor }" x-text="statusText"></span>
           </div>
   
-          <div class="info-row">
-            <span class="text-[#7b7b7b] tariff-info">Трафик</span>
-            <span class="tariff-info" x-text="trafficText"></span>
+          <div class="info-row" x-show="isBsActive">
+            <span class="text-[#7b7b7b] tariff-info">Трафик (белый список)</span>
+            <span class="tariff-info" x-text="bsTrafficText"></span>
           </div>
   
           <div class="info-row">


### PR DESCRIPTION
## Что сделано

Добавила отображение трафика по белому списку (bs) вместо обычного 
трафика на страницах:
- Настройка VPN
- Лимит устройств
- Истекшая подписка
- Отозванная подписка

## Логика (одинакова на всех страницах)

- Если `bs_monthly_limit_total > 0` — показываем блок «Трафик (белый список)» 
  с данными из `bs_monthly_used` / `bs_monthly_limit_total`.
- Если `bs_monthly_limit_total` не задан (null/0) — блок трафика скрывается 
  целиком (`x-show="isBsActive"`).

## Изменения

- `userData`: добавлены поля `bs_monthly_used`, `bs_monthly_limit_total` 
  (на всех затронутых шаблонах)
- Alpine-компонент: добавлены геттеры `isBsActive`, `bsTrafficText`
- Старая логика отображения обычного трафика удалена

## Примечание

Логика продублирована в 4 шаблонах (нет общего JS-файла для переиспользования 
в текущей структуре репозитория) — при необходимости можно вынести в отдельный 
файл позже.