### PR TITLE
NPVPN-1867: фикс ошибки formatUserAgent is not defined на странице подписки

### DIFF
--- a/templates/sub/index.html
+++ b/templates/sub/index.html
@@ -84,6 +84,19 @@
             return lower.includes('windows') || lower.includes('linux') || lower.includes('pc');
           },
 
+          formatUserAgent(userAgent) {
+            if (!userAgent) return 'Неизвестно';
+
+            const parts = userAgent.split('/');
+            if (parts.length >= 3) {
+                return `${parts[0]}/${parts[1]}`;
+            }
+
+            return userAgent.length > 20 
+                ? userAgent.substring(0, 20) + '...' 
+                : userAgent;
+          },
+
           copyTerminalCommands() {
             const text = document.getElementById('linux-commands').innerText;
             navigator.clipboard.writeText(text).then(() => {


### PR DESCRIPTION
## Что сделано

Исправлена ошибка `formatUserAgent is not defined` на странице устройств.

## Проблема

В разметке использовался вызов `formatUserAgent(device.user_agent)`, 
но метод отсутствовал в Alpine-компоненте (`subscriptionManager`) — 
падала ошибка в консоли, user agent устройств не отображался.

## Решение

Добавлен метод `formatUserAgent` в компонент — реализация перенесена 
с другой страницы, где такая же логика уже используется (форматирует 
строку вида `AppName/Version/...` в `AppName/Version`, либо обрезает 
длинные строки до 20 символов).