### PR TITLE
NPVPN-1879: expire в MySQL переводим с INT на BIGINT

### DIFF
--- a/app/db/migrations/versions/071beb7b9077_npvpn_1879_expire_int_to_bigint.py
+++ b/app/db/migrations/versions/071beb7b9077_npvpn_1879_expire_int_to_bigint.py
@@ -1,0 +1,67 @@
+"""NPVPN-1879 expire int to bigint
+
+Revision ID: 071beb7b9077
+Revises: d7e9f1a2b3c4
+Create Date: 2026-08-20 10:57:32.072436
+
+`users.expire` и `next_plans.expire` в MySQL были INT, то есть верхняя граница
+срока подписки — 2147483647 (2038-01-19 03:14:07). Бессрочные подписки бота
+выставляют ровно этот потолок, и любое продление поверх него (реферальные дни,
+бонусы) роняло UPDATE:
+
+    (pymysql.err.DataError) (1264, "Out of range value for column 'expire' at row 1")
+
+Панель отвечала боту 500, синк уходил в бесконечные ретраи, а сверка держала
+вечное расхождение expire_drift. Независимо от этого кейса INT-потолок всё
+равно упирается в 2038 год для любой годовой подписки.
+
+Под SQLite миграция ничего не делает: там INTEGER и так 64-битный.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '071beb7b9077'
+down_revision = 'd7e9f1a2b3c4'
+branch_labels = None
+depends_on = None
+
+INT32_MAX = 2147483647
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.engine.name != 'mysql':
+        return
+
+    op.alter_column('users', 'expire',
+                    existing_type=sa.Integer(),
+                    type_=sa.BigInteger(),
+                    existing_nullable=True)
+    op.alter_column('next_plans', 'expire',
+                    existing_type=sa.Integer(),
+                    type_=sa.BigInteger(),
+                    existing_nullable=True)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.engine.name != 'mysql':
+        return
+
+    # Значения, не влезающие обратно в INT, прижимаем к потолку: без этого
+    # ALTER упал бы ровно той же ошибкой 1264, из-за которой миграция и
+    # появилась. Срок при откате теряет точность, но остаётся бессрочным
+    # в том же смысле, что и до миграции.
+    op.execute(f"UPDATE users SET expire = {INT32_MAX} WHERE expire > {INT32_MAX}")
+    op.execute(f"UPDATE next_plans SET expire = {INT32_MAX} WHERE expire > {INT32_MAX}")
+
+    op.alter_column('next_plans', 'expire',
+                    existing_type=sa.BigInteger(),
+                    type_=sa.Integer(),
+                    existing_nullable=True)
+    op.alter_column('users', 'expire',
+                    existing_type=sa.BigInteger(),
+                    type_=sa.Integer(),
+                    existing_nullable=True)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -138,7 +138,11 @@ class User(Base):
         default=UserDataLimitResetStrategy.no_reset,
     )
     usage_logs = relationship("UserUsageResetLogs", back_populates="user")  # maybe rename it to reset_usage_logs?
-    expire = Column(Integer, nullable=True)
+    # BigInteger, а не Integer: в MySQL Integer — это INT со сроком жизни до
+    # 2038-01-19 03:14:07 (2147483647). Бессрочные подписки бота выставляют
+    # именно этот потолок, и любое продление поверх него роняло UPDATE с
+    # "Out of range value for column 'expire'" (NPVPN-1879).
+    expire = Column(BigInteger, nullable=True)
     admin_id = Column(Integer, ForeignKey("admins.id"))
     admin = relationship("Admin", back_populates="users")
     sub_revoked_at = Column(DateTime, nullable=True, default=None)
@@ -345,7 +349,7 @@ class NextPlan(Base):
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     data_limit = Column(BigInteger, nullable=False)
-    expire = Column(Integer, nullable=True)
+    expire = Column(BigInteger, nullable=True)  # см. User.expire (NPVPN-1879)
     add_remaining_traffic = Column(Boolean, nullable=False, default=False, server_default="0")
     fire_on_either = Column(Boolean, nullable=False, default=True, server_default="0")
 

--- a/tests/test_expire_bigint_migration.py
+++ b/tests/test_expire_bigint_migration.py
@@ -1,0 +1,127 @@
+"""Миграция expire INT -> BIGINT (NPVPN-1879).
+
+В MySQL Integer — это INT с потолком 2147483647 (2038-01-19 03:14:07).
+Бессрочные подписки бота выставляют ровно этот потолок, и продление поверх
+него роняло UPDATE ошибкой 1264 "Out of range value for column 'expire'",
+из-за чего панель отвечала боту 500 на каждом синке.
+
+SQLite тут ничего не доказывает — там INTEGER и так 64-битный, — поэтому
+проверяем то, что проверить можно: dialect-guard и объявленный тип колонок.
+"""
+
+from __future__ import annotations
+
+import glob
+import importlib.util
+import os
+import sys
+import types
+
+import sqlalchemy as sa
+
+# app/__init__.py тяжёлый, а app.subscription.share тянет за собой весь стек
+# генерации ссылок — тот же обход, что в test_node_metrics.py.
+for _name, _module in list(sys.modules.items()):
+    if _name.startswith("app.") and not hasattr(_module, "__file__") and not hasattr(_module, "__path__"):
+        del sys.modules[_name]
+
+_share_stub = types.ModuleType("app.subscription.share")
+_share_stub.generate_v2ray_links = lambda *args, **kwargs: []
+sys.modules.setdefault("app.subscription.share", _share_stub)
+
+from app.db.models import NextPlan, User  # noqa: E402
+
+
+def _load_migration():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    matches = glob.glob(os.path.join(here, "app/db/migrations/versions/*_npvpn_1879_expire_int_to_bigint.py"))
+    assert len(matches) == 1, f"expected exactly one expire migration, got {matches}"
+    spec = importlib.util.spec_from_file_location("expire_bigint_migration", matches[0])
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bind(dialect: str):
+    class _Engine:
+        name = dialect
+
+    class _Bind:
+        engine = _Engine()
+
+    return _Bind()
+
+
+class _RecordingOp:
+    """Заглушка alembic.op: записывает вызовы вместо похода в БД."""
+
+    def __init__(self, dialect: str):
+        self._bind = _bind(dialect)
+        self.altered: list[tuple[str, str, object]] = []
+        self.executed: list[str] = []
+
+    def get_bind(self):
+        return self._bind
+
+    def alter_column(self, table, column, **kwargs):
+        self.altered.append((table, column, kwargs.get("type_")))
+
+    def execute(self, statement):
+        self.executed.append(str(statement))
+
+
+def test_models_declare_bigint_expire():
+    assert isinstance(User.__table__.c.expire.type, sa.BigInteger)
+    assert isinstance(NextPlan.__table__.c.expire.type, sa.BigInteger)
+
+
+def test_upgrade_widens_both_tables_on_mysql(monkeypatch):
+    migration = _load_migration()
+    op = _RecordingOp("mysql")
+    monkeypatch.setattr(migration, "op", op)
+
+    migration.upgrade()
+
+    assert [(table, column) for table, column, _ in op.altered] == [("users", "expire"), ("next_plans", "expire")]
+    assert all(isinstance(type_, sa.BigInteger) for _, _, type_ in op.altered)
+
+
+def test_upgrade_is_noop_on_sqlite(monkeypatch):
+    """SQLite и так хранит 64-битные целые — ALTER там не нужен и не поддержан."""
+    migration = _load_migration()
+    op = _RecordingOp("sqlite")
+    monkeypatch.setattr(migration, "op", op)
+
+    migration.upgrade()
+
+    assert op.altered == []
+    assert op.executed == []
+
+
+def test_downgrade_clamps_before_narrowing(monkeypatch):
+    """Сужение обратно до INT обязано сначала прижать значения к потолку.
+
+    Иначе откат падает ровно той же ошибкой 1264, из-за которой миграция и
+    появилась.
+    """
+    migration = _load_migration()
+    op = _RecordingOp("mysql")
+    monkeypatch.setattr(migration, "op", op)
+
+    migration.downgrade()
+
+    assert len(op.executed) == 2
+    assert all(str(migration.INT32_MAX) in statement for statement in op.executed)
+    assert [(table, column) for table, column, _ in op.altered] == [("next_plans", "expire"), ("users", "expire")]
+    assert all(type(type_) is sa.Integer for _, _, type_ in op.altered)
+
+
+def test_downgrade_is_noop_on_sqlite(monkeypatch):
+    migration = _load_migration()
+    op = _RecordingOp("sqlite")
+    monkeypatch.setattr(migration, "op", op)
+
+    migration.downgrade()
+
+    assert op.altered == []
+    assert op.executed == []

--- a/tests/test_panel_settings_migration.py
+++ b/tests/test_panel_settings_migration.py
@@ -51,7 +51,9 @@ def test_alembic_versions_have_single_head():
             continue
         parents.update(down if isinstance(down, (tuple, list)) else (down,))
     heads = sorted(r for r in revs if r not in parents)
-    assert heads == ["d7e9f1a2b3c4"], f"expected one alembic head, got {heads} ({[revs[h] for h in heads]})"
+    # Проверяем сам инвариант — «голова одна», — а не её конкретный id: иначе
+    # каждая новая миграция обязана править этот тест, хотя ветвления нет.
+    assert len(heads) == 1, f"expected one alembic head, got {heads} ({[revs[h] for h in heads]})"
 
 
 class _Op:


### PR DESCRIPTION
## Что и зачем

`users.expire` и `next_plans.expire` в MySQL были `INT`, то есть срок подписки упирался в 2147483647 (2038-01-19 03:14:07). Бессрочные подписки бота выставляют ровно этот потолок, и любое продление поверх него (реферальные дни) роняло `UPDATE`, панель отвечала боту 500, а синк уходил в бесконечные ретраи.

Найдено на проде opl при проверке в рамках NPVPN-1879: подписка 40622 висела в сверке с 05.08 и раз в час зажигала алерт `Marzban sync resync stopped`.

```
sqlalchemy.exc.DataError: (pymysql.err.DataError) (1264, "Out of range value for column 'expire' at row 1")
[SQL: UPDATE users SET expire=%(expire)s, edit_at=%(edit_at)s WHERE users.id = %(users_id)s]
[parameters: {'expire': 2150507647, ..., 'users_id': 33329}]
```

Независимо от этого кейса INT-потолок всё равно упирается в 2038 год для любой годовой подписки, так что миграция нужна сама по себе.

## Изменения

- `User.expire` и `NextPlan.expire`: `Integer` → `BigInteger`
- миграция `071beb7b9077` (`down_revision = d7e9f1a2b3c4`): `ALTER TABLE ... MODIFY expire BIGINT NULL` **только под MySQL** — в SQLite `INTEGER` и так 64-битный
- `downgrade` перед сужением прижимает значения к `2147483647`: иначе откат падает той же ошибкой 1264
- тест «одна alembic-голова» проверял конкретный id головы и падал на любой новой миграции — переписан на сам инвариант (`len(heads) == 1`)
- новый `tests/test_expire_bigint_migration.py`: типы колонок, `ALTER` обеих таблиц под MySQL, no-op под SQLite, кламп в `downgrade`

## Заметки для ревью

- **Миграция БД.** На проде opl `users` — 115 636 строк / 33 МБ, MySQL 9.6. Смена типа идёт `ALGORITHM=COPY`, то есть таблица закрыта на запись на время `ALTER` — на таком объёме это секунды, но не ноль.
- **MySQL-часть автотестами не покрыта:** тесты панели ходят в SQLite, где миграция — no-op. Проверял сгенерированный offline-SQL:

  ```sql
  ALTER TABLE users MODIFY expire BIGINT NULL;
  ALTER TABLE next_plans MODIFY expire BIGINT NULL;
  ```

  Живой прогон на MySQL — на стенде.
- Текущий `alembic_version` на проде — `d7e9f1a2b3c4`, миграция встаёт следом без ветвления.
- **Порядок выкатки: панель → бот.** Парный PR бота — npvpn/telegram_bot#229 (`limited` перестаёт быть расхождением сверки), он от этого PR не зависит и наоборот.

## Проверки

```
358 passed
ruff check / format — чисто
```