### PR TITLE
NPVPN-1912/fix cahnge status of node

### DIFF
--- a/app/jobs/0_xray_core.py
+++ b/app/jobs/0_xray_core.py
@@ -7,6 +7,7 @@ from app.models.node import NodeStatus
 from app.xray.node import NodeAPIError
 from config import (
     JOB_CORE_HEALTH_CHECK_INTERVAL,
+    XRAY_NODE_CONNECT_STALE_TIMEOUT,
     XRAY_NODE_ERROR_RECONNECT_INTERVAL,
     XRAY_NODE_MAX_CONCURRENT_CONNECTS,
 )
@@ -16,8 +17,14 @@ _error_reconnect_last: dict[int, float] = {}
 
 
 def _should_force_reconnect(node_id: int, status: NodeStatus, now: float) -> bool:
-    if status == NodeStatus.connecting and xray.operations.is_connect_stale(node_id):
-        return True
+    if status == NodeStatus.connecting:
+        if xray.operations.is_connect_stale(node_id):
+            return True
+        # Soft-defer leaves connecting without an active lock; escalate by DB age.
+        age = xray.operations.connecting_age_seconds(node_id)
+        if age is not None and age >= XRAY_NODE_CONNECT_STALE_TIMEOUT:
+            return True
+        return False
     if status != NodeStatus.error:
         return False
     last_attempt = _error_reconnect_last.get(node_id, 0)

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from datetime import datetime
 from functools import cache
 from typing import TYPE_CHECKING
 
@@ -544,6 +545,17 @@ def _change_node_status(node_id: int, status: NodeStatus, message: str = None, v
             raise
 
 
+def connecting_age_seconds(node_id: int) -> float | None:
+    """Seconds since node entered connecting (DB last_status_change), or None."""
+    with GetDB() as db:
+        dbnode = crud.get_node_by_id(db, node_id)
+        if not dbnode or dbnode.status != NodeStatus.connecting:
+            return None
+        if not dbnode.last_status_change:
+            return None
+        return max(0.0, (datetime.utcnow() - dbnode.last_status_change).total_seconds())
+
+
 global _connecting_nodes
 _connecting_nodes = set()
 _connecting_started_at = {}
@@ -643,10 +655,13 @@ def _connect_node_impl(node_id, config=None, force: bool = False):
             logger.info(f"[connect_node] skip disabled node_id={dbnode.id}")
             return
 
-        status_changed = _change_node_status(node_id, NodeStatus.connecting)
-        if not status_changed:
-            logger.info(f"[connect_node] status update rejected for node_id={node_id}")
-            return
+        # Soft retries leave status=connecting; do not rewrite it (would reset last_status_change
+        # and wipe xray_version), so health can escalate via connecting_age_seconds.
+        if dbnode.status != NodeStatus.connecting:
+            status_changed = _change_node_status(node_id, NodeStatus.connecting)
+            if not status_changed:
+                logger.info(f"[connect_node] status update rejected for node_id={node_id}")
+                return
 
         if config is None:
             config = xray.config.include_db_users()
@@ -706,13 +721,15 @@ def _connect_node_impl(node_id, config=None, force: bool = False):
                             node.start(config_json=config_json)
                     except Exception as soft_exc:
                         if getattr(node, "_session_id", None):
-                            # Session still remembered — do not escalate to error/hard /connect.
+                            # Session still remembered — do not escalate to error/hard /connect yet.
+                            # IMPORTANT: do NOT mark DB status=connected here. That caused fake
+                            # "Подключен" without xray_version and blocked recovery (health assumed OK).
+                            # Leave status=connecting; health retries soft, then HARD after stale.
                             logger.debug(
                                 f'[connect_node] SOFT deferred node_id={node_id} ("{dbnode.name}"): '
                                 f"{type(soft_exc).__name__}: {soft_exc}; "
-                                f"keep session_id, status=connected, retry later (no /connect)"
+                                f"keep session_id, status=connecting, retry later (no /connect)"
                             )
-                            _change_node_status(node_id, NodeStatus.connected)
                             return
                         logger.debug(
                             f"[connect_node] SOFT failed without session node_id={node_id} "
@@ -839,4 +856,5 @@ __all__ = [
     "restart_node",
     "is_connect_in_progress",
     "is_connect_stale",
+    "connecting_age_seconds",
 ]

--- a/tests/test_soft_deferred_status.py
+++ b/tests/test_soft_deferred_status.py
@@ -1,0 +1,206 @@
+"""Regression: soft deferred must not leave fake DB status=connected."""
+
+import sys
+import types
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+# Same harness as test_record_bs_usage: models → user → share breaks under conftest stubs.
+for _name, _module in list(sys.modules.items()):
+    if _name.startswith("app.") and not hasattr(_module, "__file__") and not hasattr(_module, "__path__"):
+        del sys.modules[_name]
+
+_share_stub = types.ModuleType("app.subscription.share")
+_share_stub.generate_v2ray_links = lambda *args, **kwargs: []
+sys.modules.setdefault("app.subscription.share", _share_stub)
+
+from app.models.node import NodeStatus  # noqa: E402
+from app.xray import operations  # noqa: E402
+
+if sys.modules.get("app.subscription.share") is _share_stub:
+    del sys.modules["app.subscription.share"]
+
+
+def test_connecting_age_seconds():
+    dbnode = MagicMock()
+    dbnode.status = NodeStatus.connecting
+    dbnode.last_status_change = datetime.utcnow() - timedelta(seconds=150)
+
+    with (
+        patch.object(operations, "GetDB") as get_db,
+        patch.object(operations, "crud") as crud,
+    ):
+        get_db.return_value.__enter__.return_value = MagicMock()
+        get_db.return_value.__exit__.return_value = None
+        crud.get_node_by_id.return_value = dbnode
+        age = operations.connecting_age_seconds(6)
+        assert age is not None and age >= 149
+
+
+def test_soft_deferred_does_not_mark_connected():
+    dbnode = MagicMock()
+    dbnode.id = 6
+    dbnode.name = "nl-3"
+    dbnode.status = NodeStatus.connected
+    dbnode.inbounds = []
+    dbnode.xray_version = "26.2.6"
+
+    node = MagicMock()
+    node._session_id = "sess-1"
+    node.try_restore.side_effect = Exception("timeout")
+
+    status_calls = []
+
+    def capture_status(node_id, status, message=None, version=None):
+        status_calls.append((node_id, status, version))
+        return True
+
+    with (
+        patch.object(operations, "_acquire_connect_slot", return_value=True),
+        patch.object(operations, "_release_connect_slot"),
+        patch.object(operations, "_connect_semaphore") as sem,
+        patch.object(operations, "GetDB") as get_db,
+        patch.object(operations, "crud") as crud,
+        patch.object(operations, "_change_node_status", side_effect=capture_status),
+        patch.object(operations, "xray") as xray_mod,
+        patch.object(operations, "node_config_json", return_value="{}"),
+        patch.object(operations, "_cascade_kwargs", return_value={"role": "direct"}),
+        patch.object(operations, "_blocked_user_ids", return_value=set()),
+    ):
+        sem.acquire = MagicMock()
+        sem.release = MagicMock()
+        get_db.return_value.__enter__.return_value = MagicMock()
+        get_db.return_value.__exit__.return_value = None
+        crud.get_node_by_id.return_value = dbnode
+        xray_mod.nodes = {6: node}
+        xray_mod.config.include_db_users.return_value = MagicMock()
+
+        operations._connect_node_impl(6, config=MagicMock(), force=False)
+
+    assert any(s == NodeStatus.connecting for _, s, _ in status_calls)
+    assert not any(s == NodeStatus.connected for _, s, _ in status_calls)
+    node.start.assert_not_called()
+    node.connect.assert_not_called()
+
+
+def test_soft_retry_skips_status_rewrite_when_already_connecting():
+    """Re-entering soft connect must not reset last_status_change via connecting rewrite."""
+    dbnode = MagicMock()
+    dbnode.id = 6
+    dbnode.name = "nl-3"
+    dbnode.status = NodeStatus.connecting
+    dbnode.inbounds = []
+
+    node = MagicMock()
+    node._session_id = "sess-1"
+    node.try_restore.side_effect = Exception("timeout")
+
+    with (
+        patch.object(operations, "_acquire_connect_slot", return_value=True),
+        patch.object(operations, "_release_connect_slot"),
+        patch.object(operations, "_connect_semaphore") as sem,
+        patch.object(operations, "GetDB") as get_db,
+        patch.object(operations, "crud") as crud,
+        patch.object(operations, "_change_node_status") as change_status,
+        patch.object(operations, "xray") as xray_mod,
+        patch.object(operations, "node_config_json", return_value="{}"),
+        patch.object(operations, "_cascade_kwargs", return_value={"role": "direct"}),
+        patch.object(operations, "_blocked_user_ids", return_value=set()),
+    ):
+        sem.acquire = MagicMock()
+        sem.release = MagicMock()
+        get_db.return_value.__enter__.return_value = MagicMock()
+        get_db.return_value.__exit__.return_value = None
+        crud.get_node_by_id.return_value = dbnode
+        xray_mod.nodes = {6: node}
+
+        operations._connect_node_impl(6, config=MagicMock(), force=False)
+
+    change_status.assert_not_called()
+
+
+def _run_soft_deferred(dbnode, node, status_calls):
+    def capture_status(node_id, status, message=None, version=None):
+        status_calls.append((node_id, status, version))
+        dbnode.status = status
+        if version is not None:
+            dbnode.xray_version = version
+        elif status == NodeStatus.connecting:
+            dbnode.xray_version = None
+        return True
+
+    with (
+        patch.object(operations, "_acquire_connect_slot", return_value=True),
+        patch.object(operations, "_release_connect_slot"),
+        patch.object(operations, "_connect_semaphore") as sem,
+        patch.object(operations, "GetDB") as get_db,
+        patch.object(operations, "crud") as crud,
+        patch.object(operations, "_change_node_status", side_effect=capture_status),
+        patch.object(operations, "xray") as xray_mod,
+        patch.object(operations, "node_config_json", return_value="{}"),
+        patch.object(operations, "_cascade_kwargs", return_value={"role": "direct"}),
+        patch.object(operations, "_blocked_user_ids", return_value=set()),
+    ):
+        sem.acquire = MagicMock()
+        sem.release = MagicMock()
+        get_db.return_value.__enter__.return_value = MagicMock()
+        get_db.return_value.__exit__.return_value = None
+        crud.get_node_by_id.return_value = dbnode
+        xray_mod.nodes = {dbnode.id: node}
+        xray_mod.config.include_db_users.return_value = MagicMock()
+        operations._connect_node_impl(dbnode.id, config=MagicMock(), force=False)
+
+
+def test_scenario_soft_outage_stays_connecting_then_stale_forces_hard():
+    """Full bug path (network outage + kept session_id) vs fix + HARD escalation.
+
+    OLD bug: soft deferred marked DB=connected without xray_version → UI «Подключен»
+    without badge, health assumed OK, no reconnect.
+
+    FIX: stay connecting (no fake connected); after stale age health must force HARD.
+    """
+    dbnode = MagicMock()
+    dbnode.id = 6
+    dbnode.name = "rare-jp3"
+    dbnode.status = NodeStatus.connected
+    dbnode.inbounds = []
+    dbnode.xray_version = "26.2.6"
+    dbnode.last_status_change = datetime.utcnow()
+
+    node = MagicMock()
+    node._session_id = "sess-kept-across-blip"
+    node.try_restore.side_effect = Exception("Connection timed out")
+
+    status_calls = []
+    _run_soft_deferred(dbnode, node, status_calls)
+
+    # After soft deferred: must look like "connecting", never fake connected.
+    assert dbnode.status == NodeStatus.connecting
+    assert not any(s == NodeStatus.connected for _, s, _ in status_calls)
+    # Version wiped on entering connecting — badge only after real get_version.
+    assert dbnode.xray_version is None
+    node.connect.assert_not_called()
+
+    # Soft retries while still connecting must not rewrite status (stale clock).
+    status_calls.clear()
+    _run_soft_deferred(dbnode, node, status_calls)
+    assert status_calls == []
+    assert dbnode.status == NodeStatus.connecting
+
+    # Stale connecting → health escalates to HARD (same predicate as 0_xray_core).
+    dbnode.last_status_change = datetime.utcnow() - timedelta(seconds=130)
+    with (
+        patch.object(operations, "GetDB") as get_db,
+        patch.object(operations, "crud") as crud,
+        patch.object(operations, "is_connect_stale", return_value=False),
+        patch.object(operations, "XRAY_NODE_CONNECT_STALE_TIMEOUT", 120),
+    ):
+        get_db.return_value.__enter__.return_value = MagicMock()
+        get_db.return_value.__exit__.return_value = None
+        crud.get_node_by_id.return_value = dbnode
+
+        age = operations.connecting_age_seconds(dbnode.id)
+        assert age is not None and age >= 120
+        # Mirrors _should_force_reconnect for status=connecting without active lock.
+        force = age >= 120
+        assert force is True


### PR DESCRIPTION
NPVPN-1912: soft deferred не ставит фейковый connected без версии xray

## Что и зачем
После soft reconnect при обрыве REST нода могла остаться в UI как «Подключен» без бейджа версии Xray: soft deferred ошибочно писал в БД `status=connected` без `xray_version`. Health считал ноду живой, HARD не эскалировался; помогал только Save/Reconnect. Исправляем: при soft deferred оставляем `connecting`, а если так слишком долго — health уходит в HARD.

## Изменения
- Soft deferred больше не вызывает `_change_node_status(connected)` — статус остаётся `connecting`, session_id сохраняется для soft reattach
- Повторный soft при уже `connecting` не переписывает статус (не сбрасывает `last_status_change`)
- `connecting_age_seconds` + health: если `connecting` дольше `XRAY_NODE_CONNECT_STALE_TIMEOUT` (default 120s) → `connect_node(force=True)`
- Регресс-тесты: `tests/test_soft_deferred_status.py` (сценарий outage → connecting → stale → HARD)

## Заметки для ревью
- Миграций нет — откат кода на master по схеме БД безопасен
- Env не меняется; таймаут уже есть: `XRAY_NODE_CONNECT_STALE_TIMEOUT`
- Бейдж версии только после реального `get_version()` на успешном connect

## Проверка (chaos A/B на ноде nl-3)

Скрипт на ноде: `sudo ./block-rest.sh 150` (или 300, чтобы успеть глянуть UI).  
Панель: `LOG_LEVEL=DEBUG`, фильтр логов:
`[health]|[connect_node]|[node.session]`

### С фиксом (ветка NPVPN-1912/xray-nodes)
1. Сразу: `ping failed … keep session_id` → `schedule SOFT` → `SOFT deferred … status=connecting`
2. ~2 мин soft-retry без `/connect`
3. ~120s: `schedule HARD connect_node(force=True)` → `/connect` + `/restart`
4. После unblock: `DONE … path=HARD xray=v…`, в UI бейдж версии, нода доступна
5. На ноде при HARD: `Xray core stopped` / `Restarting` — ожидаемо

### Без фикса (master / откат)
1. `SOFT deferred … status=connected` — ключевой маркер бага
2. Во время block в UI: «Подключен» **без** бейджа Xray (явно воспроизвели)
3. HARD по stale **нет**; после unblock soft может сам восстановиться (`try_restore=OK` → version снова есть) — но фейковый connected без version во время/после обрыва остаётся, на проде отсюда залипание без HARD

Unit: `pytest tests/test_soft_deferred_status.py` — ok