### PR TITLE
NPVPN-1963/change limit's logic

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -345,7 +345,7 @@
   "botSettings.subRevokedAnnounceText": "Revoked announce text",
   "botSettings.subExpiredAnnounceText": "Expired announce text",
   "botSettings.subDeviceLimitHardMode": "Hard device limit stub",
-  "botSettings.subDeviceLimitHardModeHint": "On: stub servers only. Off (default): stub servers listed above main servers.",
+  "botSettings.subDeviceLimitHardModeHint": "On: real limit — new devices over the limit are not added; extras get stub servers only. Off (default): warning only — devices can be added freely; extras get stub servers listed above main servers.",
   "botSettings.subDeviceLimitAnnounceText": "Device limit announce text",
   "botSettings.subUnsupportedClientAnnounceText": "Unsupported client announce text",
   "botSettings.subRevokedServerText": "Revoked server text",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -314,7 +314,7 @@
   "botSettings.subRevokedAnnounceText": "متن اعلان لغو",
   "botSettings.subExpiredAnnounceText": "متن اعلان انقضا",
   "botSettings.subDeviceLimitHardMode": "جایگزین سخت محدودیت دستگاه",
-  "botSettings.subDeviceLimitHardModeHint": "فعال: فقط سرورهای جایگزین. غیرفعال (پیش‌فرض): جایگزین‌ها بالای سرورهای اصلی.",
+  "botSettings.subDeviceLimitHardModeHint": "فعال: محدودیت واقعی — دستگاه‌های جدید بیش از حد اضافه نمی‌شوند و دستگاه‌های اضافی فقط جایگزین می‌بینند. غیرفعال (پیش‌فرض): هشدار — دستگاه‌ها بدون محدودیت اضافه می‌شوند و اضافی‌ها جایگزین بالای سرورهای اصلی می‌گیرند.",
   "botSettings.subDeviceLimitAnnounceText": "متن اعلان محدودیت دستگاه",
   "botSettings.subUnsupportedClientAnnounceText": "متن اعلان کلاینت پشتیبانی‌نشده",
   "botSettings.subRevokedServerText": "متن سرور لغوشده",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -345,7 +345,7 @@
   "botSettings.subRevokedAnnounceText": "Текст объявления при отзыве",
   "botSettings.subExpiredAnnounceText": "Текст объявления при истечении",
   "botSettings.subDeviceLimitHardMode": "Жёсткая заглушка при лимите устройств",
-  "botSettings.subDeviceLimitHardModeHint": "Включено: только заглушки. Выключено (по умолчанию): заглушки поверх основных серверов.",
+  "botSettings.subDeviceLimitHardModeHint": "Включено: реальный лимит — новые устройства сверх лимита не добавляются, у лишних только заглушка. Выключено (по умолчанию): предупреждение — устройства добавляются без ограничения, у сверх лимита заглушка поверх серверов.",
   "botSettings.subDeviceLimitAnnounceText": "Текст объявления при лимите устройств",
   "botSettings.subUnsupportedClientAnnounceText": "Текст объявления для неподдерживаемого клиента",
   "botSettings.subRevokedServerText": "Текст серверов при отзыве",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -310,7 +310,7 @@
   "botSettings.subRevokedAnnounceText": "撤销公告文本",
   "botSettings.subExpiredAnnounceText": "过期公告文本",
   "botSettings.subDeviceLimitHardMode": "设备限制硬占位",
-  "botSettings.subDeviceLimitHardModeHint": "开启：仅显示占位服务器。关闭（默认）：占位服务器列在主要服务器之上。",
+  "botSettings.subDeviceLimitHardModeHint": "开启：真实限制——超出上限的新设备不会被添加，多余设备仅显示占位服务器。关闭（默认）：仅警告——设备可任意添加，超出上限的设备在主要服务器之上显示占位。",
   "botSettings.subDeviceLimitAnnounceText": "设备限制公告文本",
   "botSettings.subUnsupportedClientAnnounceText": "不支持客户端公告文本",
   "botSettings.subRevokedServerText": "撤销服务器文本",

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -784,6 +784,9 @@ def get_user_devices(db: Session, dbuser: User) -> list[UserDevice]:
     return db.query(UserDevice).filter(UserDevice.user_id == dbuser.id).order_by(UserDevice.last_seen.desc()).all()
 
 
+UNKNOWN_DEVICE_HWID = "Неизвестное устройство"
+
+
 def get_user_active_devices(db: Session, dbuser: User) -> list[UserDevice]:
     return (
         db.query(UserDevice)
@@ -794,6 +797,40 @@ def get_user_active_devices(db: Session, dbuser: User) -> list[UserDevice]:
         .order_by(UserDevice.last_seen.desc())
         .all()
     )
+
+
+def get_user_active_devices_by_first_seen(db: Session, dbuser: User) -> list[UserDevice]:
+    return (
+        db.query(UserDevice)
+        .filter(
+            UserDevice.user_id == dbuser.id,
+            UserDevice.status == "active",
+        )
+        .order_by(UserDevice.first_seen.asc(), UserDevice.id.asc())
+        .all()
+    )
+
+
+def is_device_within_limit(db: Session, dbuser: User, dbdevice: UserDevice | None) -> bool:
+    """True if the device is among the first N active by first_seen (then id)."""
+    limit = dbuser.device_limit
+    if not limit:
+        return True
+    if dbdevice is None:
+        return False
+    for index, device in enumerate(get_user_active_devices_by_first_seen(db, dbuser)):
+        if device.id == dbdevice.id:
+            return index < int(limit)
+    return False
+
+
+def _hard_mode_blocks_new_device(db: Session, dbuser: User, *, hard_mode: bool) -> bool:
+    if not hard_mode:
+        return False
+    limit = dbuser.device_limit
+    if not limit:
+        return False
+    return count_user_devices(db, dbuser) >= int(limit)
 
 
 def get_user_device(db: Session, dbuser: User, device_id: int) -> UserDevice | None:
@@ -905,23 +942,22 @@ def register_user_device(
     ver_os: str | None,
     device_model: str | None,
     user_agent: str | None,
+    *,
+    hard_mode: bool = False,
 ) -> tuple[bool, bool]:
-    unknown_hwid = "Неизвестное устройство"
     if not hwid:
-        dbdevice = get_user_device_by_hwid(db, dbuser, unknown_hwid)
+        dbdevice = get_user_device_by_hwid(db, dbuser, UNKNOWN_DEVICE_HWID)
         if dbdevice:
             if _unknown_user_agents_match(cast(str | None, dbdevice.user_agent), user_agent):
                 _update_unknown_device_metadata(dbdevice, device_os, ver_os, device_model, user_agent)
                 db.commit()
                 return True, False
             return False, True
-        if dbuser.device_limit:
-            current = count_user_devices(db, dbuser)
-            if current >= dbuser.device_limit:
-                return False, False
+        if _hard_mode_blocks_new_device(db, dbuser, hard_mode=hard_mode):
+            return False, False
         dbdevice = UserDevice(
             user_id=dbuser.id,
-            hwid=unknown_hwid,
+            hwid=UNKNOWN_DEVICE_HWID,
             device_os=device_os,
             ver_os=ver_os,
             device_model=device_model,
@@ -948,10 +984,8 @@ def register_user_device(
         db.commit()
         return True, False
 
-    if dbuser.device_limit:
-        current = count_user_devices(db, dbuser)
-        if current >= dbuser.device_limit:
-            return False, False
+    if _hard_mode_blocks_new_device(db, dbuser, hard_mode=hard_mode):
+        return False, False
 
     dbdevice = UserDevice(
         user_id=dbuser.id,

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -39,6 +39,7 @@ from app.models.user import (
     UsersUsagesResponse,
     UserUsagesResponse,
 )
+from app.subscription.bot_settings import resolve_bot_settings
 from app.utils import report, responses
 from app.utils.request_context import request_id_var
 from config import SYNC_INBOUNDS_DB_CHUNK_SIZE, SYNC_INBOUNDS_MAX_CONCURRENCY
@@ -259,7 +260,8 @@ def add_user_device(
     dbuser: UserResponse = Depends(get_validated_user),
     db: Session = Depends(get_db),
 ):
-    if dbuser.device_limit and crud.count_user_devices(db, dbuser) >= dbuser.device_limit:
+    hard_mode = bool(resolve_bot_settings(cast(DBUser, dbuser)).get("sub_device_limit_hard_mode"))
+    if hard_mode and dbuser.device_limit and crud.count_user_devices(db, dbuser) >= dbuser.device_limit:
         raise HTTPException(status_code=403, detail="Device limit reached")
     try:
         dbdevice = crud.create_user_device(db, dbuser, device)

--- a/app/subscription/user_info.py
+++ b/app/subscription/user_info.py
@@ -85,23 +85,28 @@ def resolve_device_limit_subscription_state(
 ) -> tuple[UserResponse, bool, bool, bool]:
     """Returns user, device_limited, device_limited_hard_for_gen, unsupported_blocks."""
     device_limited = False
-    hard_device_limited = False
+    device_limited_hard_for_gen = False
     unsupported_client = False
+    hard_mode = bool(bot_settings.get("sub_device_limit_hard_mode"))
     if not is_revoked and not is_expired:
         registered, unsupported_client = crud.register_user_device(
-            db, dbuser, x_hwid, x_device_os, x_ver_os, x_device_model, user_agent
+            db,
+            dbuser,
+            x_hwid,
+            x_device_os,
+            x_ver_os,
+            x_device_model,
+            user_agent,
+            hard_mode=hard_mode,
         )
-        hard_device_limited = not registered and not unsupported_client
-        device_limited = hard_device_limited or crud.is_device_limit_exceeded(db, dbuser)
+        dbdevice = None
+        if registered:
+            dbdevice = crud.get_user_device_by_hwid(db, dbuser, x_hwid or crud.UNKNOWN_DEVICE_HWID)
+        within_limit = crud.is_device_within_limit(db, dbuser, dbdevice)
+        over_limit = not unsupported_client and not within_limit
+        device_limited = over_limit
+        device_limited_hard_for_gen = over_limit and hard_mode
     unsupported_blocks = unsupported_client
-    hard_mode = bool(bot_settings.get("sub_device_limit_hard_mode"))
-    if (
-        is_revoked
-        or is_expired
-        or unsupported_blocks
-        or (hard_mode and device_limited)
-        or (not hard_mode and hard_device_limited)
-    ):
+    if is_revoked or is_expired or unsupported_blocks or device_limited_hard_for_gen:
         user = get_empty_subscription_user(user)
-    device_limited_hard_for_gen = (hard_mode and device_limited) or (not hard_mode and hard_device_limited)
     return user, device_limited, device_limited_hard_for_gen, unsupported_blocks

--- a/tests/test_device_limit_subscription.py
+++ b/tests/test_device_limit_subscription.py
@@ -1,0 +1,193 @@
+"""Лимит устройств в /sub: ранжирование по first_seen и soft/hard заглушки."""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+for _name, _module in list(sys.modules.items()):
+    if _name.startswith("app.") and not hasattr(_module, "__file__") and not hasattr(_module, "__path__"):
+        del sys.modules[_name]
+
+_share_stub = types.ModuleType("app.subscription.share")
+_share_stub.generate_v2ray_links = lambda *args, **kwargs: []
+sys.modules.setdefault("app.subscription.share", _share_stub)
+
+from app.db.base import Base  # noqa: E402
+from app.db.crud import (  # noqa: E402
+    UNKNOWN_DEVICE_HWID,
+    count_user_devices,
+    get_user_device_by_hwid,
+    is_device_within_limit,
+    register_user_device,
+)
+from app.db.models import User, UserDevice  # noqa: E402
+from app.subscription.user_info import resolve_device_limit_subscription_state  # noqa: E402
+
+if sys.modules.get("app.subscription.share") is _share_stub:
+    del sys.modules["app.subscription.share"]
+
+USER_ID = 1001
+BASE_SEEN = datetime(2026, 1, 1, 12, 0, 0)
+
+
+class FakeSubUser:
+    def __init__(self, proxies=None, inbounds=None):
+        self.proxies = proxies if proxies is not None else {"vless": {"id": "x"}}
+        self.inbounds = inbounds if inbounds is not None else {"vless": ["in"]}
+
+    def model_copy(self, update=None):
+        other = FakeSubUser(proxies=dict(self.proxies), inbounds=dict(self.inbounds))
+        if update:
+            other.proxies = update.get("proxies", other.proxies)
+            other.inbounds = update.get("inbounds", other.inbounds)
+        return other
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add(User(id=USER_ID, username="limit_user", created_at=datetime.utcnow(), device_limit=4))
+        session.commit()
+        yield session
+
+
+def _user(db: Session) -> User:
+    return db.query(User).filter(User.id == USER_ID).one()
+
+
+def _add_device(db: Session, hwid: str, *, minutes: int, status: str = "active") -> UserDevice:
+    seen = BASE_SEEN + timedelta(minutes=minutes)
+    device = UserDevice(
+        user_id=USER_ID,
+        hwid=hwid,
+        status=status,
+        first_seen=seen,
+        last_seen=seen,
+    )
+    db.add(device)
+    db.commit()
+    db.refresh(device)
+    return device
+
+
+def _resolve(db: Session, dbuser: User, hwid: str | None, *, hard_mode: bool):
+    user = FakeSubUser()
+    return resolve_device_limit_subscription_state(
+        user,
+        db,
+        dbuser,
+        False,
+        False,
+        {"sub_device_limit_hard_mode": hard_mode},
+        user_agent="Happ/1.0/Android",
+        x_hwid=hwid,
+        x_device_os="Android",
+        x_ver_os="14",
+        x_device_model="Pixel",
+    )
+
+
+def test_is_device_within_limit_first_n_by_first_seen(db):
+    devices = [_add_device(db, f"hwid-{i}", minutes=i) for i in range(7)]
+    dbuser = _user(db)
+    for device in devices[:4]:
+        assert is_device_within_limit(db, dbuser, device) is True
+    for device in devices[4:]:
+        assert is_device_within_limit(db, dbuser, device) is False
+    assert is_device_within_limit(db, dbuser, None) is False
+
+
+def test_is_device_within_limit_without_limit(db):
+    dbuser = _user(db)
+    dbuser.device_limit = None
+    db.commit()
+    device = _add_device(db, "hwid-a", minutes=0)
+    assert is_device_within_limit(db, dbuser, device) is True
+    assert is_device_within_limit(db, dbuser, None) is True
+
+
+def test_existing_extras_soft_overlay_hard_only(db):
+    devices = [_add_device(db, f"hwid-{i}", minutes=i) for i in range(7)]
+    dbuser = _user(db)
+
+    in_limit_user, limited, hard, unsupported = _resolve(db, dbuser, devices[0].hwid, hard_mode=False)
+    assert (limited, hard, unsupported) == (False, False, False)
+    assert in_limit_user.proxies
+
+    extra_soft_user, limited, hard, unsupported = _resolve(db, dbuser, devices[4].hwid, hard_mode=False)
+    assert (limited, hard, unsupported) == (True, False, False)
+    assert extra_soft_user.proxies
+
+    extra_hard_user, limited, hard, unsupported = _resolve(db, dbuser, devices[6].hwid, hard_mode=True)
+    assert (limited, hard, unsupported) == (True, True, False)
+    assert extra_hard_user.proxies == {}
+
+
+def test_exactly_at_limit_known_device_is_clean(db):
+    devices = [_add_device(db, f"hwid-{i}", minutes=i) for i in range(4)]
+    dbuser = _user(db)
+    user, limited, hard, unsupported = _resolve(db, dbuser, devices[3].hwid, hard_mode=True)
+    assert (limited, hard, unsupported) == (False, False, False)
+    assert user.proxies
+
+
+def test_new_hwid_at_limit_soft_adds_overlay(db):
+    for i in range(4):
+        _add_device(db, f"hwid-{i}", minutes=i)
+    dbuser = _user(db)
+    user, limited, hard, unsupported = _resolve(db, dbuser, "hwid-new", hard_mode=False)
+    assert (limited, hard, unsupported) == (True, False, False)
+    assert user.proxies
+    assert count_user_devices(db, dbuser) == 5
+    assert get_user_device_by_hwid(db, dbuser, "hwid-new") is not None
+
+
+def test_new_hwid_at_limit_hard_does_not_add(db):
+    for i in range(4):
+        _add_device(db, f"hwid-{i}", minutes=i)
+    dbuser = _user(db)
+    user, limited, hard, unsupported = _resolve(db, dbuser, "hwid-new", hard_mode=True)
+    assert (limited, hard, unsupported) == (True, True, False)
+    assert user.proxies == {}
+    assert count_user_devices(db, dbuser) == 4
+    assert get_user_device_by_hwid(db, dbuser, "hwid-new") is None
+
+
+def test_no_device_limit_adds_and_not_limited(db):
+    dbuser = _user(db)
+    dbuser.device_limit = None
+    db.commit()
+    user, limited, hard, unsupported = _resolve(db, dbuser, "hwid-new", hard_mode=True)
+    assert (limited, hard, unsupported) == (False, False, False)
+    assert user.proxies
+    assert get_user_device_by_hwid(db, dbuser, "hwid-new") is not None
+
+
+def test_register_soft_allows_over_limit_hard_blocks(db):
+    dbuser = _user(db)
+    for i in range(4):
+        _add_device(db, f"hwid-{i}", minutes=i)
+
+    registered, unsupported = register_user_device(db, dbuser, "soft-new", None, None, None, "Happ", hard_mode=False)
+    assert (registered, unsupported) == (True, False)
+    assert get_user_device_by_hwid(db, dbuser, "soft-new") is not None
+
+    registered, unsupported = register_user_device(db, dbuser, "hard-new", None, None, None, "Happ", hard_mode=True)
+    assert (registered, unsupported) == (False, False)
+    assert get_user_device_by_hwid(db, dbuser, "hard-new") is None
+
+
+def test_unknown_hwid_constant_used_for_empty_header(db):
+    dbuser = _user(db)
+    registered, unsupported = register_user_device(db, dbuser, None, None, None, None, "Happ/1.0", hard_mode=False)
+    assert (registered, unsupported) == (True, False)
+    assert get_user_device_by_hwid(db, dbuser, UNKNOWN_DEVICE_HWID) is not None


### PR DESCRIPTION
NPVPN-1963: заглушки лимита устройств по first_seen

## Что и зачем
При превышении лимита заглушка ставилась всем устройствам, а новое сверх лимита всегда получало жёсткую заглушку даже в мягком режиме. Теперь первые N устройств по first_seen остаются без заглушек. Мягкая — предупреждение: устройства добавляются, у лишних заглушка поверх серверов. Жёсткая — реальный лимит: новые сверх N не добавляются, у лишних только заглушка.

## Изменения
- ранг активных устройств по first_seen, затем id: 1..N без заглушек, остальные — overlay или only-stub
- soft: новые устройства всегда добавляются; hard: кап регистрации при count >= N
- POST /user/{username}/devices в soft не режет по лимиту
- хинт hard_mode в локалях панели
- тесты ранжирования и soft/hard для in-limit, extra и нового hwid

## Заметки для ревью
- миграция не нужна, first_seen уже в user_devices
- HTML limited.html и условие её выдачи (count >= N) не менялись
- перед мержем: rebase на свежий origin/master