### PR TITLE
NPVPN-1966: писать last_seen_at в node_user_usages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,10 @@ UVICORN_PORT = 8000
 
 # JOB_CORE_HEALTH_CHECK_INTERVAL = 10
 # JOB_RECORD_NODE_USAGES_INTERVAL = 30
+# Период тика учёта трафика, секунды. Он же — потолок точности всех панелей
+# «присутствия» на Grafana-дашборде: окно presence_window там обязано быть
+# >= JOB_RECORD_USER_USAGES_INTERVAL/60 + буфер (NPVPN-1966).
+# Локально 10; на проде — 300.
 # JOB_RECORD_USER_USAGES_INTERVAL = 10
 # JOB_REVIEW_USERS_INTERVAL = 10
 # JOB_SEND_NOTIFICATIONS_INTERVAL = 30

--- a/app/db/migrations/versions/c3dff0f8e830_npvpn_1966_node_user_usage_last_seen.py
+++ b/app/db/migrations/versions/c3dff0f8e830_npvpn_1966_node_user_usage_last_seen.py
@@ -1,0 +1,56 @@
+"""npvpn_1966_node_user_usage_last_seen
+
+Revision ID: c3dff0f8e830
+Revises: 071beb7b9077
+Create Date: 2026-08-31 19:26:01.655958
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3dff0f8e830"
+down_revision = "071beb7b9077"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Колонка добавляется в конец таблицы, nullable и без server_default —
+    # только в этом случае MySQL 8+/9 применяет ALGORITHM=INSTANT и не
+    # перестраивает node_user_usages (~75M строк, 11 ГБ).
+    #
+    # Бэкфилла нет намеренно: у существующих строк last_seen_at IS NULL, а
+    # фильтр дашборда `last_seen_at >= NOW() - INTERVAL N MINUTE` их отсекает
+    # сам — таблица приходит в рабочее состояние за один тик джобы.
+    op.add_column("node_user_usages", sa.Column("last_seen_at", sa.DateTime(), nullable=True))
+
+    # Покрывающий индекс под панель «Connections by Node»: она берёт окно в два
+    # часа по created_at (~400k строк) и резидуально фильтрует по last_seen_at.
+    # Без него резидуальный фильтр ломает покрываемость idx_ca_node_traffic и
+    # каждая строка окна превращается в PK-lookup.
+    #
+    # На MySQL идёт через ALTER с ALGORITHM=INPLACE, LOCK=NONE: построение на
+    # ~75M строк занимает 5–20 минут, и всё это время апдейты record_user_usages
+    # не блокируются. Панель на это время не поднимется — выкатывать в окно
+    # низкой нагрузки.
+    bind = op.get_bind()
+    if bind.engine.name == "mysql":
+        op.execute(
+            "ALTER TABLE node_user_usages "
+            "ADD INDEX idx_ca_lastseen_node_user (created_at, last_seen_at, node_id, user_id), "
+            "ALGORITHM=INPLACE, LOCK=NONE"
+        )
+    else:
+        op.create_index(
+            "idx_ca_lastseen_node_user",
+            "node_user_usages",
+            ["created_at", "last_seen_at", "node_id", "user_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_ca_lastseen_node_user", table_name="node_user_usages")
+    op.drop_column("node_user_usages", "last_seen_at")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -545,6 +545,10 @@ class NodeUserUsage(Base):
     node_id = Column(Integer, ForeignKey("nodes.id"))
     node = relationship("Node", back_populates="user_usages")
     used_traffic = Column(BigInteger, default=0)
+    # Момент последнего тика, в котором по этой паре (user, node) реально шёл
+    # трафик. created_at округлён до часа и потому не отличает «сидит сейчас»
+    # от «пинганул 55 минут назад» — дашборд присутствия смотрит сюда (NPVPN-1966).
+    last_seen_at = Column(DateTime, nullable=True, default=None)
 
 
 class NodeUserBsUsage(Base):

--- a/app/jobs/record_usages.py
+++ b/app/jobs/record_usages.py
@@ -55,7 +55,8 @@ def record_user_stats(params: list, node_id: int | None, consumption_factor: int
     if not params:
         return
 
-    created_at = datetime.fromisoformat(datetime.utcnow().strftime("%Y-%m-%dT%H:00:00"))
+    now = datetime.utcnow()
+    created_at = datetime.fromisoformat(now.strftime("%Y-%m-%dT%H:00:00"))
 
     with GetDB() as db:
         # make user usage row if doesn't exist
@@ -73,14 +74,22 @@ def record_user_stats(params: list, node_id: int | None, consumption_factor: int
 
         if uids_to_insert:
             stmt = insert(NodeUserUsage).values(
-                user_id=bindparam("uid"), created_at=created_at, node_id=node_id, used_traffic=0
+                user_id=bindparam("uid"),
+                created_at=created_at,
+                node_id=node_id,
+                used_traffic=0,
+                last_seen_at=now,
             )
             safe_execute(db, stmt, [{"uid": uid} for uid in uids_to_insert])
 
         # record
         stmt = (
             update(NodeUserUsage)
-            .values(used_traffic=NodeUserUsage.used_traffic + bindparam("value") * consumption_factor)
+            .values(
+                used_traffic=NodeUserUsage.used_traffic + bindparam("value") * consumption_factor,
+                # Тот же UPDATE, что уже идёт каждый тик — дополнительных запросов к БД нет.
+                last_seen_at=now,
+            )
             .where(
                 and_(
                     NodeUserUsage.user_id == bindparam("uid"),

--- a/tests/test_record_usages_last_seen.py
+++ b/tests/test_record_usages_last_seen.py
@@ -1,0 +1,124 @@
+"""last_seen_at в node_user_usages (NPVPN-1966).
+
+Строка (user, node, hour) живёт весь час, поэтому по created_at нельзя отличить
+«сидит сейчас» от «пинганул 55 минут назад». last_seen_at — момент последнего
+тика, в котором по этой паре реально шёл трафик.
+"""
+
+import sys
+import types
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+for _name, _module in list(sys.modules.items()):
+    if _name.startswith("app.") and not hasattr(_module, "__file__") and not hasattr(_module, "__path__"):
+        del sys.modules[_name]
+
+_share_stub = types.ModuleType("app.subscription.share")
+_share_stub.generate_v2ray_links = lambda *args, **kwargs: []
+sys.modules.setdefault("app.subscription.share", _share_stub)
+
+from app.db.base import Base  # noqa: E402
+from app.db.models import Node, NodeUserUsage, User  # noqa: E402
+from app.jobs import record_usages  # noqa: E402
+from app.jobs.record_usages import record_user_stats  # noqa: E402
+
+if sys.modules.get("app.subscription.share") is _share_stub:
+    del sys.modules["app.subscription.share"]
+
+NODE_ID = 13
+OTHER_NODE_ID = 14
+USER_ID = 45581
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add(Node(id=NODE_ID, name="node-a", address="127.0.0.1", port=62050, api_port=62051))
+        session.add(Node(id=OTHER_NODE_ID, name="node-b", address="127.0.0.2", port=62050, api_port=62051))
+        session.add(User(id=USER_ID, username="TEST100", created_at=datetime.utcnow()))
+        session.commit()
+        yield session
+
+
+@pytest.fixture
+def patched_getdb(db, monkeypatch):
+    """record_user_stats открывает свою сессию через GetDB — подменяем на тестовую."""
+
+    @contextmanager
+    def fake_getdb():
+        yield db
+
+    monkeypatch.setattr(record_usages, "GetDB", fake_getdb)
+
+
+def usage(db, node_id=NODE_ID):
+    return db.query(NodeUserUsage).filter(NodeUserUsage.node_id == node_id).one()
+
+
+def test_insert_sets_last_seen_at(db, patched_getdb):
+    before = datetime.utcnow() - timedelta(seconds=1)
+
+    record_user_stats([{"uid": USER_ID, "value": 1024}], NODE_ID)
+
+    row = usage(db)
+    assert row.last_seen_at is not None
+    assert row.last_seen_at >= before
+
+
+def test_last_seen_at_is_tick_moment_not_hour_start(db, patched_getdb):
+    record_user_stats([{"uid": USER_ID, "value": 1024}], NODE_ID)
+
+    row = usage(db)
+    # created_at округлён до начала часа, last_seen_at — нет. Именно это различие
+    # и делает панель честной.
+    assert row.created_at.minute == 0 and row.created_at.second == 0
+    assert row.last_seen_at >= row.created_at
+
+
+def test_increment_moves_last_seen_at_forward(db, patched_getdb):
+    record_user_stats([{"uid": USER_ID, "value": 1024}], NODE_ID)
+    first = usage(db).last_seen_at
+
+    db.query(NodeUserUsage).filter(NodeUserUsage.node_id == NODE_ID).update(
+        {NodeUserUsage.last_seen_at: first - timedelta(minutes=20)}
+    )
+    db.commit()
+
+    record_user_stats([{"uid": USER_ID, "value": 2048}], NODE_ID)
+
+    row = usage(db)
+    assert row.used_traffic == 3072
+    assert row.last_seen_at > first - timedelta(minutes=20)
+
+
+def test_tick_without_traffic_on_node_does_not_move_it(db, patched_getdb):
+    record_user_stats([{"uid": USER_ID, "value": 1024}], NODE_ID)
+    stale = datetime.utcnow() - timedelta(minutes=40)
+    db.query(NodeUserUsage).filter(NodeUserUsage.node_id == NODE_ID).update({NodeUserUsage.last_seen_at: stale})
+    db.commit()
+
+    # Юзер ушёл на другую ноду: тик приносит трафик только по OTHER_NODE_ID.
+    record_user_stats([{"uid": USER_ID, "value": 4096}], OTHER_NODE_ID)
+
+    assert usage(db, NODE_ID).last_seen_at == stale
+    assert usage(db, OTHER_NODE_ID).last_seen_at > stale
+
+
+def test_migration_keeps_column_instant_addable():
+    """Колонка обязана быть nullable и без server_default.
+
+    Иначе MySQL 9 откажется от ALGORITHM=INSTANT и перестроит node_user_usages
+    (~75M строк, 11 ГБ) — это часы простоя учёта трафика. Инвариант ломается
+    одной безобидной правкой модели, поэтому проверяется тестом.
+    """
+    column = NodeUserUsage.__table__.columns["last_seen_at"]
+    assert column.nullable is True
+    assert column.server_default is None


### PR DESCRIPTION
## Что и зачем

Строка `node_user_usages` создаётся на пару (user, node) и **час**, поэтому по `created_at` невозможно отличить «сидит на ноде сейчас» от «пинганул подписку 55 минут назад» — отметки последнего трафика в схеме просто не было. Grafana-панель «Connections by Node» из-за этого показывала вторых как первых, а юзера за балансировщиком — сразу на всех нодах пула.

Добавляем `node_user_usages.last_seen_at` — момент последнего тика, в котором по этой паре реально шли байты. Дашборд (отдельный PR в `telegram_bot`) переходит на неё вместо `users.online_at`.

## Изменения

- `app/db/models.py` — колонка `NodeUserUsage.last_seen_at` (nullable, без `server_default`).
- `app/jobs/record_usages.py` — `last_seen_at` проставляется в INSERT новой строки и в **уже существующий** UPDATE инкремента `used_traffic`. Дополнительных запросов к БД нет: строка и так пишется каждый тик.
- Миграция `c3dff0f8e830` — колонка + покрывающий индекс `idx_ca_lastseen_node_user (created_at, last_seen_at, node_id, user_id)`.
- `tests/test_record_usages_last_seen.py` — 5 тестов.
- `.env.example` — пояснение к `JOB_RECORD_USER_USAGES_INTERVAL`: он же потолок точности панелей присутствия.

## Заметки для ревью

- **Миграция долгая.** Построение индекса на ~75M строк занимает 5–20 минут (+2.5–3 ГБ на диск), и всё это время панель не поднимется — **выкатывать в окно низкой нагрузки**. `ALGORITHM=INPLACE, LOCK=NONE` оставляет апдейты `record_user_usages` незаблокированными, но старт панели не спасает.
- **Порядок выкатки строгий: сначала этот PR, потом дашборд в `telegram_bot`.** Обратный порядок даёт `Unknown column 'last_seen_at'` на панели Grafana.
- Колонка добавляется в конец таблицы, `nullable`, без `server_default` — только так MySQL 9 применяет `ALGORITHM=INSTANT` и не перестраивает таблицу. Инвариант закреплён тестом `test_migration_keeps_column_instant_addable`, потому что ломается одной безобидной правкой модели.
- **Бэкфилла нет намеренно**: у старых строк `last_seen_at IS NULL`, фильтр окна их отсекает сам — таблица приходит в рабочее состояние за один тик джобы.
- Индекс положен в alembic, а не в `telegram_bot/etc/mysql/optimize_node_user_usages.sql`, где лежат два предыдущих: `node_user_usages` — таблица БД панели, и её схемой должен управлять alembic панели, а не SQL-файл в репозитории бота.
- Ветка на MySQL в миграции нужна только ради `ALGORITHM=INPLACE, LOCK=NONE` — `op.create_index` этого не умеет.
- После выкатки этого PR отдельно снижаем `JOB_RECORD_USER_USAGES_INTERVAL` с 600 до 300 на проде (env, не код) — точность панелей ограничена периодом тика. Нужен замер нагрузки на MySQL: запись растёт примерно вдвое.

Проверено локально: `ruff check .` чист, 394 теста зелёные, миграция прогнана `upgrade → downgrade → upgrade` на чистой sqlite.